### PR TITLE
fix: prefer clean paths to prohibit gosec issues

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -77,12 +76,14 @@ func replaceWalkFn(path string, info os.FileInfo, pattern string, old, new []byt
 	}
 
 	if matched {
+		cleanedPath := filepath.Clean(path)
+
 		var oldContent []byte
-		if oldContent, err = ioutil.ReadFile(filepath.Clean(path)); err != nil {
+		if oldContent, err = os.ReadFile(cleanedPath); err != nil {
 			return
 		}
 
-		if err = ioutil.WriteFile(path, bytes.Replace(oldContent, old, new, -1), 0); err != nil {
+		if err = os.WriteFile(cleanedPath, bytes.Replace(oldContent, old, new, -1), 0); err != nil {
 			return
 		}
 	}
@@ -92,7 +93,7 @@ func replaceWalkFn(path string, info os.FileInfo, pattern string, old, new []byt
 
 func createFile(filePath, content string) (err error) {
 	var f *os.File
-	if f, err = os.Create(filePath); err != nil {
+	if f, err = os.Create(filepath.Clean(filePath)); err != nil {
 		return
 	}
 
@@ -153,11 +154,11 @@ func storeJson(filename string, v interface{}) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filename, b, 0600)
+	return os.WriteFile(filename, b, 0600)
 }
 
 func loadJson(filename string, v interface{}) error {
-	b, err := ioutil.ReadFile(path.Clean(filename))
+	b, err := os.ReadFile(path.Clean(filename))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ensure `filepath.Clean` is run before using vars in io-ops.

Also,
- refactor: prefer `os.ReadFile` and `os.WriteFile`

**Please provide enough information so that others can review your pull request:**

Fixes the issues mentioned by Gosec Security check (e.g. https://github.com/gofiber/cli/actions/runs/8718544897/job/23916022604)
![image](https://github.com/gofiber/cli/assets/1307809/cf5d4252-48d0-40a9-a917-2c747149c3ea)


**Explain the *details* for making this change. What existing problem does the pull request solve?**

Prefer to use cleaned paths as mentioned by gosec.

**Commit formatting** 

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/