### PR TITLE
:sparkles: Execute `go mod tidy` after basic creation

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -78,7 +78,18 @@ func createBasic(projectPath, modName string) (err error) {
 		return
 	}
 
-	return runCmd(execCommand("go", "mod", "init", modName))
+	if err = runCmd(execCommand("go", "mod", "init", modName)); err != nil{
+		return
+	}
+	
+	//Execute go mod tidy in the project directory
+	installModules := execCommand("go", "mod", "tidy")
+	installModules.Dir = fmt.Sprintf("%s%c", projectPath, os.PathSeparator)
+	if err = runCmd(installModules); err != nil{
+		return
+	}
+
+	return
 }
 
 const githubPrefix = "https://github.com/"


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

Fix to #122 

**Explain the *details* for making this change. What existing problem does the pull request solve?**

The expected use case for `fiber new <name_project>` is a working and ready to go setup. With this PR i propose to automatically install the required modules using `go mod tidy`