### PR TITLE
Fix race conditions in tests

### DIFF
--- a/cmd/dev_test.go
+++ b/cmd/dev_test.go
@@ -312,5 +312,7 @@ func getEscort() *escort {
 		},
 		ctx:       c,
 		terminate: t,
+		hitCh:     make(chan struct{}, 1),
+		sig:       make(chan os.Signal, 1),
 	}
 }

--- a/cmd/internal/prompt.go
+++ b/cmd/internal/prompt.go
@@ -2,9 +2,11 @@ package internal
 
 import (
 	"fmt"
+	"os"
 
 	input "github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/muesli/termenv"
 )
 
 type errMsg error
@@ -27,7 +29,7 @@ func NewPrompt(title string, placeholder ...string) *Prompt {
 		p.textInput.Placeholder = placeholder[0]
 	}
 
-	p.p = tea.NewProgram(p)
+	p.p = tea.NewProgram(p, tea.WithOutput(termenv.NewOutput(os.Stdout)))
 
 	return p
 }


### PR DESCRIPTION
## Summary
- fix test races by synchronizing goroutines in `escort`
- avoid bubbletea color cache races by creating separate output in `NewPrompt`
- keep parallel execution in prompt tests
- initialize channels when creating escorts in tests

## Testing
- `go test ./cmd/internal -race`
- `go test ./cmd -run Test_Dev_Escort_Run -race`
- `go test ./... -race`


------
https://chatgpt.com/codex/tasks/task_e_686e17453bc88326abc7604b105d1d3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved synchronization and graceful shutdown of background processes to ensure all tasks complete before exit.
* **Bug Fixes**
  * Enhanced handling of concurrent operations to prevent lingering background activity after termination.
* **Chores**
  * Updated prompt initialization for better output handling in terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->