### PR TITLE
Update CLI to Go 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Fiber Command Line Interface
 
 # Installation
 ```bash
-# for go version since 1.16
+# for go version 1.24 or later
 go install github.com/gofiber/cli/fiber@latest
 ```
 ```bash
-# for go version smaller than 1.16
+# for go version older than 1.24
 go get -u github.com/gofiber/cli/fiber
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/cli
 
-go 1.21
+go 1.24
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0


### PR DESCRIPTION
## Summary
- switch module and workflows to Go 1.24
- update installation instructions for Go 1.24

## Testing
- `go vet ./...`
- `go test ./... -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_686e160e22c8832694f68f7e4a2acd18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify Go version requirements for different installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->