### PR TITLE
Fix race issues in unit tests

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -57,8 +57,13 @@ func Test_Helper_LoadConfig(t *testing.T) {
 	})
 
 	t.Run("has config file", func(t *testing.T) {
-		homeDir = setupHomeDir(t, "LoadConfig")
-		defer teardownHomeDir(homeDir)
+		origHome := homeDir
+		tempHome := setupHomeDir(t, "LoadConfig")
+		homeDir = tempHome
+		defer func() {
+			homeDir = origHome
+			teardownHomeDir(tempHome)
+		}()
 
 		filename := fmt.Sprintf("%s%c%s", homeDir, os.PathSeparator, configName)
 


### PR DESCRIPTION
## Summary
- restore `homeDir` and other globals modified in tests
- reset `upgraded` and `CliVersionCheckedAt` before running version checks

## Testing
- `go test ./cmd -race -count=5`
- `go test ./... -race`


------
https://chatgpt.com/codex/tasks/task_e_686ecc4edc688326b49ef84ca747955a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring temporary changes to user directory settings are properly restored after each test.
  * Enhanced test isolation by resetting certain global variables before and after relevant tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->