### PR TITLE
Update Go to 1.24 and use gotestsum

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.x
       - name: Run Golint
         uses: reviewdog/action-golangci-lint@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -14,14 +14,10 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Cache modules
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    - name: Install gotestsum
+      run: go install gotest.tools/gotestsum@latest
     - name: Run Test
-      run: go test ./... -v -race
+      run: |
+        gotestsum --format standard-verbose -- -race ./...

--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ Fiber Command Line Interface
 [![Packaging status](https://repology.org/badge/vertical-allrepos/fiber-cli.svg)](https://repology.org/project/fiber-cli/versions)
 
 # Installation
+Requires Go 1.24 or later.
+
 ```bash
-# for go version since 1.16
 go install github.com/gofiber/cli/fiber@latest
-```
-```bash
-# for go version smaller than 1.16
-go get -u github.com/gofiber/cli/fiber
 ```
 
 # Commands

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/cli
 
-go 1.21
+go 1.24
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0


### PR DESCRIPTION
## Summary
- update Go version requirement to 1.24
- run tests with gotestsum and enable caching
- update linter workflow to Go 1.24

## Testing
- `go install gotest.tools/gotestsum@latest`
- `$(go env GOPATH)/bin/gotestsum --format standard-verbose -- -race ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686ed0afed4483268b6ae99aba7cba7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to require Go version 1.24 or later.
  * Simplified installation steps by removing outdated commands for older Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->