### PR TITLE
Add Fiber v3 migration test coverage

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -22,7 +22,16 @@ type Migration struct {
 // Example structure:
 // {"from": ">=2.0.0", "to": "<=3.*.*", "fn": [MigrateFN, MigrateFN]}
 var Migrations = []Migration{
-	{From: ">=2.0.0", To: "<4.0.0-0", Functions: []MigrationFn{v3.MigrateHandlerSignatures}},
+	{
+		From: ">=2.0.0",
+		To:   "<4.0.0-0",
+		Functions: []MigrationFn{
+			v3.MigrateHandlerSignatures,
+			v3.MigrateParserMethods,
+			v3.MigrateRedirectMethods,
+			v3.MigrateGenericHelpers,
+		},
+	},
 	{From: ">=1.0.0", To: ">=0.0.0-0", Functions: []MigrationFn{MigrateGoPkgs}},
 }
 

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -2,8 +2,11 @@ package v3
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
+	"regexp"
 	"strings"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
 
 	"github.com/gofiber/cli/cmd/internal"
 )
@@ -20,5 +23,70 @@ func MigrateHandlerSignatures(cmd *cobra.Command, cwd string, _ *semver.Version,
 
 	cmd.Println("Migrating handler signatures")
 
+	return nil
+}
+
+// MigrateParserMethods replaces deprecated parser helper methods with the new binding API
+func MigrateParserMethods(cmd *cobra.Command, cwd string, _ *semver.Version, _ *semver.Version) error {
+	replacer := strings.NewReplacer(
+		".BodyParser(", ".Bind().Body(",
+		".CookieParser(", ".Bind().Cookie(",
+		".ParamsParser(", ".Bind().URI(",
+		".QueryParser(", ".Bind().Query(",
+	)
+
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		return replacer.Replace(content)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate parser methods: %v", err)
+	}
+
+	cmd.Println("Migrating parser methods")
+	return nil
+}
+
+// MigrateRedirectMethods updates redirect helper methods to the new API
+func MigrateRedirectMethods(cmd *cobra.Command, cwd string, _ *semver.Version, _ *semver.Version) error {
+	replacer := strings.NewReplacer(
+		".RedirectBack(", ".Redirect().Back(",
+		".RedirectToRoute(", ".Redirect().Route(",
+	)
+
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		re := regexp.MustCompile(`\.Redirect\(`)
+		content = re.ReplaceAllString(content, ".Redirect().To(")
+		return replacer.Replace(content)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate redirect methods: %v", err)
+	}
+
+	cmd.Println("Migrating redirect methods")
+	return nil
+}
+
+// MigrateGenericHelpers migrates helper functions that now use generics
+func MigrateGenericHelpers(cmd *cobra.Command, cwd string, _ *semver.Version, _ *semver.Version) error {
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		reParamsInt := regexp.MustCompile(`(\w+)\.ParamsInt\(`)
+		content = reParamsInt.ReplaceAllString(content, "fiber.Params[int]($1, ")
+
+		reQueryInt := regexp.MustCompile(`(\w+)\.QueryInt\(`)
+		content = reQueryInt.ReplaceAllString(content, "fiber.Query[int]($1, ")
+
+		reQueryFloat := regexp.MustCompile(`(\w+)\.QueryFloat\(`)
+		content = reQueryFloat.ReplaceAllString(content, "fiber.Query[float64]($1, ")
+
+		reQueryBool := regexp.MustCompile(`(\w+)\.QueryBool\(`)
+		content = reQueryBool.ReplaceAllString(content, "fiber.Query[bool]($1, ")
+
+		return content
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate generic helpers: %v", err)
+	}
+
+	cmd.Println("Migrating generic helpers")
 	return nil
 }

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -1,0 +1,137 @@
+package v3
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func writeTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(content), 0o644)
+	assert.Nil(t, err)
+	return path
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	assert.Nil(t, err)
+	return string(b)
+}
+
+func newCmd(buf *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	return cmd
+}
+
+func Test_MigrateHandlerSignatures(t *testing.T) {
+	dir, err := ioutil.TempDir("", "mhstest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	file := writeTempFile(t, dir, "main.go", `package main
+import "github.com/gofiber/fiber/v2"
+func handler(c *fiber.Ctx) error { return nil }
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	assert.Nil(t, MigrateHandlerSignatures(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "*fiber.Ctx")
+	assert.Contains(t, content, "fiber.Ctx")
+	assert.Contains(t, buf.String(), "Migrating handler signatures")
+}
+
+func Test_MigrateParserMethods(t *testing.T) {
+	dir, err := ioutil.TempDir("", "mptest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	file := writeTempFile(t, dir, "main.go", `package main
+import "github.com/gofiber/fiber/v2"
+func handler(c fiber.Ctx) error {
+    var v interface{}
+    c.BodyParser(&v)
+    c.CookieParser(&v)
+    c.ParamsParser(&v)
+    c.QueryParser(&v)
+    return nil
+}
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	assert.Nil(t, MigrateParserMethods(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, ".Bind().Body(&v)")
+	assert.Contains(t, content, ".Bind().Cookie(&v)")
+	assert.Contains(t, content, ".Bind().URI(&v)")
+	assert.Contains(t, content, ".Bind().Query(&v)")
+	assert.Contains(t, buf.String(), "Migrating parser methods")
+}
+
+func Test_MigrateRedirectMethods(t *testing.T) {
+	dir, err := ioutil.TempDir("", "mrtest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	file := writeTempFile(t, dir, "main.go", `package main
+import "github.com/gofiber/fiber/v2"
+func handler(c fiber.Ctx) error {
+    c.Redirect("/foo")
+    c.RedirectBack()
+    c.RedirectToRoute("home")
+    return nil
+}
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	assert.Nil(t, MigrateRedirectMethods(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, ".Redirect().To(\"/foo\")")
+	assert.Contains(t, content, ".Redirect().Back()")
+	assert.Contains(t, content, ".Redirect().Route(\"home\")")
+	assert.Contains(t, buf.String(), "Migrating redirect methods")
+}
+
+func Test_MigrateGenericHelpers(t *testing.T) {
+	dir, err := ioutil.TempDir("", "mghtest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	file := writeTempFile(t, dir, "main.go", `package main
+import "github.com/gofiber/fiber/v2"
+func handler(c fiber.Ctx) error {
+    _ = c.ParamsInt("id", 0)
+    _ = c.QueryInt("age", 0)
+    _ = c.QueryFloat("score", 0.5)
+    _ = c.QueryBool("ok", true)
+    return nil
+}
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	assert.Nil(t, MigrateGenericHelpers(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "fiber.Params[int](c, \"id\"")
+	assert.Contains(t, content, "fiber.Query[int](c, \"age\"")
+	assert.Contains(t, content, "fiber.Query[float64](c, \"score\"")
+	assert.Contains(t, content, "fiber.Query[bool](c, \"ok\"")
+	assert.Contains(t, buf.String(), "Migrating generic helpers")
+}


### PR DESCRIPTION
## Summary
- test migration functions for Fiber v3
- adjust redirect migration to avoid duplicate replacements

## Testing
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687296763da48326bf15649ec01f2215