### PR TITLE
Add force & skip go mod options for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ fiber migrate --to 3.0.0
 ### Options
 
 ```text
-  -t, --to string   Migrate to a specific version e.g:3.0.0 Format: X.Y.Z
-  -h, --help        help for migrate
+  -t, --to string        Migrate to a specific version e.g:3.0.0 Format: X.Y.Z
+  -f, --force            Force migration even if already on the version
+  -s, --skip_go_mod      Skip running go mod tidy, download and vendor
+  -h, --help             help for migrate
 ```
 
 ## fiber upgrade

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -69,7 +69,7 @@ func main() {
 	require.NoError(t, os.Chdir(dir))
 	defer func() { require.NoError(t, os.Chdir(cwd)) }()
 
-	cmd := newMigrateCmd("go.mod")
+	cmd := newMigrateCmd()
 	setupCmd()
 	defer teardownCmd()
 	out, err := runCobraCmd(cmd, "-t=3.0.0")
@@ -156,7 +156,7 @@ require github.com/gofiber/fiber/v3 v3.0.0
 	defer func() { require.NoError(t, os.Chdir(cwd)) }()
 
 	t.Run("without force", func(t *testing.T) {
-		cmd := newMigrateCmd("go.mod")
+		cmd := newMigrateCmd()
 		out, err := runCobraCmd(cmd, "-t=3.0.0")
 		require.Error(t, err)
 		assert.Contains(t, out, "not greater")
@@ -174,7 +174,7 @@ require github.com/gofiber/fiber/v3 v3.0.0
 		}
 		defer func() { execCommand = origExec }()
 
-		cmd := newMigrateCmd("go.mod")
+		cmd := newMigrateCmd()
 		out, err := runCobraCmd(cmd, "-t=3.0.0", "-f")
 		require.NoError(t, err)
 		assert.Contains(t, out, "Migration from Fiber 3.0.0 to 3.0.0")
@@ -193,10 +193,10 @@ require github.com/gofiber/fiber/v3 v3.0.0
 		}
 		defer func() { execCommand = origExec }()
 
-		cmd := newMigrateCmd("go.mod")
+		cmd := newMigrateCmd()
 		out, err := runCobraCmd(cmd, "-t=3.0.0", "-f", "-s")
 		require.NoError(t, err)
 		assert.Contains(t, out, "Migration from Fiber 3.0.0 to 3.0.0")
-		assert.Len(t, cmds, 0)
+		assert.Empty(t, cmds)
 	})
 }


### PR DESCRIPTION
## Summary
- add `force` and `skip_go_mod` flags to `migrate` command
- document new flags in README
- allow forced migration for current version
- add tests for force and skip_go_mod behaviors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68742ac5b8e48326a1448c51bb74b873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for forcing migration to the same version with a new `--force` option.
  * Added an option to skip Go module maintenance steps during migration with `--skip_go_mod`.

* **Documentation**
  * Updated documentation to include the new `--force` and `--skip_go_mod` options for the migration command.

* **Tests**
  * Introduced tests to verify the new force and skip options work as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->