### PR TITLE
Fix fiber upgrade with go install

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -35,7 +35,7 @@ func upgradeRunE(cmd *cobra.Command, _ []string) error {
 }
 
 func upgrade(cmd *cobra.Command, cliLatestVersion string) {
-	module := "github.com/gofiber/cli/fiber@" + cliLatestVersion
+	module := "github.com/gofiber/cli/fiber@v" + cliLatestVersion
 	upgrader := execCommand("go", "install", module)
 	upgrader.Env = append(upgrader.Env, os.Environ()...)
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -35,9 +35,9 @@ func upgradeRunE(cmd *cobra.Command, _ []string) error {
 }
 
 func upgrade(cmd *cobra.Command, cliLatestVersion string) {
-	upgrader := execCommand("go", "get", "-u", "-v", "github.com/gofiber/cli/fiber")
+	module := fmt.Sprintf("github.com/gofiber/cli/fiber@%s", cliLatestVersion)
+	upgrader := execCommand("go", "install", module)
 	upgrader.Env = append(upgrader.Env, os.Environ()...)
-	upgrader.Env = append(upgrader.Env, "GO111MODULE=off")
 
 	scmd := internal.NewSpinnerCmd(upgrader, "Upgrading")
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -35,7 +35,7 @@ func upgradeRunE(cmd *cobra.Command, _ []string) error {
 }
 
 func upgrade(cmd *cobra.Command, cliLatestVersion string) {
-	module := fmt.Sprintf("github.com/gofiber/cli/fiber@%s", cliLatestVersion)
+	module := "github.com/gofiber/cli/fiber@" + cliLatestVersion
 	upgrader := execCommand("go", "install", module)
 	upgrader.Env = append(upgrader.Env, os.Environ()...)
 


### PR DESCRIPTION
## Summary
- update the upgrade command to use `go install`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874ad4cf0f48326a3e6e5e3129f02bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the Fiber CLI upgrade process to install specific versions more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->