### PR TITLE
Fix migrate tests failing after version tests

### DIFF
--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -107,6 +107,7 @@ func teardownCurrentVersionFile() {
 	if err := os.Remove(currentVersionFile); err != nil && !os.IsNotExist(err) {
 		panic(err)
 	}
+	currentVersionFile = "go.mod"
 }
 
 func Test_Version_Latest(t *testing.T) {


### PR DESCRIPTION
## Summary
- reset `currentVersionFile` global variable after removing temporary version files in tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68763148699083268ea26aae2634cdf7