### PR TITLE
Add timeout middleware migrator

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -54,6 +54,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateLimiterConfig,
 			v3migrations.MigrateEnvVarConfig,
 			v3migrations.MigrateSessionConfig,
+			v3migrations.MigrateTimeoutConfig,
 			v3migrations.MigrateReqHeaderParser,
 			MigrateGoVersion("1.24"),
 		},

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -506,6 +506,20 @@ func MigrateSessionConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) 
 	return nil
 }
 
+// MigrateTimeoutConfig updates timeout middleware usage to the new Config parameter
+func MigrateTimeoutConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	re := regexp.MustCompile(`timeout\.New\(\s*([^,\n]+)\s*,\s*([^\n)]+)\)`)
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		return re.ReplaceAllString(content, `timeout.New($1, timeout.Config{Timeout: $2})`)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate timeout middleware configs: %w", err)
+	}
+
+	cmd.Println("Migrating timeout middleware configs")
+	return nil
+}
+
 // MigrateAppTestConfig updates app.Test calls to use the new TestConfig parameter
 func MigrateAppTestConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	err := internal.ChangeFileContent(cwd, func(content string) string {

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -778,3 +778,27 @@ var _ = session.New(session.Config{
 	assert.NotContains(t, content, "Expiration:")
 	assert.Contains(t, buf.String(), "Migrating session middleware configs")
 }
+
+func Test_MigrateTimeoutConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mtimeout")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2"
+    "github.com/gofiber/fiber/v2/middleware/timeout"
+    "time"
+)
+var _ = timeout.New(func(c fiber.Ctx) error { return nil }, 2*time.Second)`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateTimeoutConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `timeout.New(func(c fiber.Ctx) error { return nil }, timeout.Config{Timeout: 2*time.Second})`)
+	assert.Contains(t, buf.String(), "Migrating timeout middleware configs")
+}


### PR DESCRIPTION
## Summary
- add migration for timeout middleware usage
- include new migrator in migration list
- test timeout migrator

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687cf1638b7c8326a36c44e36f7cc698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved migration process to automatically update timeout middleware configuration to the new format during version upgrades.

* **Tests**
  * Added tests to verify correct migration of timeout middleware configuration and confirmation messages during the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->