### PR TITLE
Add basicauth authorizer migration

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -55,6 +55,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateEnvVarConfig,
 			v3migrations.MigrateSessionConfig,
 			v3migrations.MigrateTimeoutConfig,
+			v3migrations.MigrateBasicauthAuthorizer,
 			v3migrations.MigrateReqHeaderParser,
 			MigrateGoVersion("1.24"),
 		},

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -598,3 +598,18 @@ func MigrateReqHeaderParser(cmd *cobra.Command, cwd string, _, _ *semver.Version
 	cmd.Println("Migrating request header parser helper")
 	return nil
 }
+
+// MigrateBasicauthAuthorizer updates inline basicauth authorizer functions to include the context parameter
+func MigrateBasicauthAuthorizer(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	re := regexp.MustCompile(`Authorizer:\s*func\(([^)]*)\)`)
+
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		return re.ReplaceAllString(content, `Authorizer: func($1, _ fiber.Ctx)`)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate basicauth authorizer: %w", err)
+	}
+
+	cmd.Println("Migrating basicauth authorizer")
+	return nil
+}

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -802,3 +802,28 @@ var _ = timeout.New(func(c fiber.Ctx) error { return nil }, 2*time.Second)`)
 	assert.Contains(t, content, `timeout.New(func(c fiber.Ctx) error { return nil }, timeout.Config{Timeout: 2*time.Second})`)
 	assert.Contains(t, buf.String(), "Migrating timeout middleware configs")
 }
+
+func Test_MigrateBasicauthAuthorizer(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mbauthorizer")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2"
+    "github.com/gofiber/fiber/v2/middleware/basicauth"
+)
+var _ = basicauth.New(basicauth.Config{
+    Authorizer: func(u, p string) bool { return true },
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateBasicauthAuthorizer(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `Authorizer: func(u, p string, _ fiber.Ctx) bool`)
+	assert.Contains(t, buf.String(), "Migrating basicauth authorizer")
+}


### PR DESCRIPTION
## Summary
- add migration to update basicauth Authorizer signature
- register migration and test it

## Testing
- `make format`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688637215668832683f09b98e49fbdf7