### PR TITLE
Add shutdown hook migrator

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -41,6 +41,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateMount,
 			v3migrations.MigrateConfigListenerFields,
 			v3migrations.MigrateListenerCallbacks,
+			v3migrations.MigrateShutdownHook,
 			v3migrations.MigrateListenMethods,
 			v3migrations.MigrateContextMethods,
 			v3migrations.MigrateCORSConfig,

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -398,6 +398,26 @@ func MigrateListenerCallbacks(cmd *cobra.Command, cwd string, _, _ *semver.Versi
 	return nil
 }
 
+// MigrateShutdownHook updates the deprecated OnShutdown hook to OnPostShutdown
+// and adapts inline hook functions to accept the error parameter.
+func MigrateShutdownHook(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		reName := regexp.MustCompile(`\.Hooks\(\)\.OnShutdown\(`)
+		content = reName.ReplaceAllString(content, ".Hooks().OnPostShutdown(")
+
+		reInline := regexp.MustCompile(`\.OnPostShutdown\(func\(\s*\)`)
+		content = reInline.ReplaceAllString(content, ".OnPostShutdown(func(err error)")
+
+		return content
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate shutdown hooks: %w", err)
+	}
+
+	cmd.Println("Migrating shutdown hooks")
+	return nil
+}
+
 // MigrateFilesystemMiddleware replaces deprecated filesystem middleware with static middleware
 func MigrateFilesystemMiddleware(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	err := internal.ChangeFileContent(cwd, func(content string) string {

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -827,3 +827,26 @@ var _ = basicauth.New(basicauth.Config{
 	assert.Contains(t, content, `Authorizer: func(u, p string, _ fiber.Ctx) bool`)
 	assert.Contains(t, buf.String(), "Migrating basicauth authorizer")
 }
+
+func Test_MigrateShutdownHook(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mhooks")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2"
+func main() {
+    app := fiber.New()
+    app.Hooks().OnShutdown(func() error { return nil })
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateShutdownHook(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `.Hooks().OnPostShutdown(func(err error) error {`)
+	assert.Contains(t, buf.String(), "Migrating shutdown hooks")
+}


### PR DESCRIPTION
## Summary
- add migrator to update OnShutdown hooks to OnPostShutdown
- register the migrator in migration list
- add tests for the new migration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68865a5ab46c8326a0c37cf1f1d4736e