### PR TITLE
Add migration for KeyLookup to Extractor in session config

### DIFF
--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -515,6 +515,41 @@ func MigrateSessionConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) 
 		reConfig := regexp.MustCompile(`session\.Config{[^}]*}`)
 		return reConfig.ReplaceAllStringFunc(content, func(s string) string {
 			s = strings.ReplaceAll(s, "Expiration:", "IdleTimeout:")
+
+			// Handle KeyLookup to Extractor migration
+			reKeyLookup := regexp.MustCompile(`(\s*)KeyLookup:\s*"([^"]+)"(,?)(\n?)`)
+			s = reKeyLookup.ReplaceAllStringFunc(s, func(match string) string {
+				sub := reKeyLookup.FindStringSubmatch(match)
+				indent := sub[1]
+				keyLookup := sub[2]
+				comma := sub[3]
+				newline := sub[4]
+
+				parts := strings.Split(keyLookup, ":")
+				if len(parts) != 2 {
+					// Invalid format, remove
+					return ""
+				}
+
+				source := parts[0]
+				name := parts[1]
+
+				var extractor string
+				switch source {
+				case "cookie":
+					extractor = fmt.Sprintf("Extractor: session.FromCookie(%q)", name)
+				case "header":
+					extractor = fmt.Sprintf("Extractor: session.FromHeader(%q)", name)
+				case "query":
+					extractor = fmt.Sprintf("Extractor: session.FromQuery(%q)", name)
+				default:
+					// Unsupported source, remove
+					return ""
+				}
+
+				return fmt.Sprintf("%s%s%s%s", indent, extractor, comma, newline)
+			})
+
 			return s
 		})
 	})

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -779,6 +779,98 @@ var _ = session.New(session.Config{
 	assert.Contains(t, buf.String(), "Migrating session middleware configs")
 }
 
+func Test_MigrateSessionConfig_KeyLookup_Cookie(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msessionkl_cookie")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/session"
+var _ = session.New(session.Config{
+    KeyLookup: "cookie:session_id",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, `Extractor: session.FromCookie("session_id")`)
+	assert.Contains(t, buf.String(), "Migrating session middleware configs")
+}
+
+func Test_MigrateSessionConfig_KeyLookup_Header(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msessionkl_header")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/session"
+var _ = session.New(session.Config{
+    KeyLookup: "header:X-Session-ID",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, `Extractor: session.FromHeader("X-Session-ID")`)
+	assert.Contains(t, buf.String(), "Migrating session middleware configs")
+}
+
+func Test_MigrateSessionConfig_KeyLookup_Query(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msessionkl_query")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/session"
+var _ = session.New(session.Config{
+    KeyLookup: "query:session_id",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, `Extractor: session.FromQuery("session_id")`)
+	assert.Contains(t, buf.String(), "Migrating session middleware configs")
+}
+
+func Test_MigrateSessionConfig_KeyLookup_Unknown(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msessionkl_unknown")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/session"
+var _ = session.New(session.Config{
+    KeyLookup: "unknown:session_id",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.NotContains(t, content, "Extractor")
+	assert.Contains(t, buf.String(), "Migrating session middleware configs")
+}
+
 func Test_MigrateTimeoutConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implement migration logic to convert `KeyLookup` configurations to `Extractor` in session middleware. Include tests for various scenarios, ensuring proper handling of cookie, header, and query sources, as well as unsupported formats.