### PR TITLE
Fix listener config migration

### DIFF
--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -365,11 +365,40 @@ func MigrateTrustedProxyConfig(cmd *cobra.Command, cwd string, _, _ *semver.Vers
 // listener configuration fields.
 func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	err := internal.ChangeFileContent(cwd, func(content string) string {
-		replacer := strings.NewReplacer(
-			"Prefork:", "EnablePrefork:",
-			"Network:", "ListenerNetwork:",
-		)
-		return replacer.Replace(content)
+		// collect fields that were moved from Config to ListenConfig
+		moved := []string{}
+		reMoved := regexp.MustCompile(`(?m)^\s*(Prefork|Network|DisableStartupMessage|EnablePrintRoutes):\s*([^,]+),?\n`)
+		content = reMoved.ReplaceAllStringFunc(content, func(m string) string {
+			sub := reMoved.FindStringSubmatch(m)
+			if len(sub) == 3 {
+				name := sub[1]
+				val := strings.TrimSpace(sub[2])
+				switch name {
+				case "Prefork":
+					name = "EnablePrefork"
+				case "Network":
+					name = "ListenerNetwork"
+				}
+				moved = append(moved, fmt.Sprintf("%s: %s", name, val))
+			}
+			return ""
+		})
+
+		if len(moved) == 0 {
+			return content
+		}
+
+		// inject ListenConfig with the moved fields if Listen is used without config
+		reListen := regexp.MustCompile(`\.Listen\(([^,\n]+)\)`)
+		content = reListen.ReplaceAllStringFunc(content, func(m string) string {
+			if strings.Contains(m, "ListenConfig{") {
+				return m
+			}
+			addr := reListen.FindStringSubmatch(m)[1]
+			return fmt.Sprintf(".Listen(%s, fiber.ListenConfig{%s})", addr, strings.Join(moved, ", "))
+		})
+
+		return content
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate listener related config fields: %w", err)

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -485,8 +485,10 @@ func main() {
     app := fiber.New(fiber.Config{
         Prefork: true,
         Network: "tcp",
+        DisableStartupMessage: true,
+        EnablePrintRoutes: true,
     })
-    _ = app
+    app.Listen(":3000")
 }`)
 
 	var buf bytes.Buffer
@@ -494,8 +496,7 @@ func main() {
 	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.Contains(t, content, "EnablePrefork: true")
-	assert.Contains(t, content, "ListenerNetwork: \"tcp\"")
+	assert.Contains(t, content, "fiber.ListenConfig{EnablePrefork: true, ListenerNetwork: \"tcp\", DisableStartupMessage: true, EnablePrintRoutes: true}")
 	assert.Contains(t, buf.String(), "Migrating listener related config fields")
 }
 


### PR DESCRIPTION
## Summary
- move Prefork, Network, DisableStartupMessage and EnablePrintRoutes fields from `fiber.Config` to `fiber.ListenConfig`
- update listener migration tests

## Testing
- `go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -shuffle=on`
- ❌ `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0 run ./...` *(fails: can't load config - Go 1.23 vs. 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6888ca5c6558832686a65efdaf1d37de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration of listener-related configuration fields for a more accurate and context-aware update process.

* **Tests**
  * Updated migration tests to cover additional configuration fields and validate the new transformation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->