### PR TITLE
Update migration for moved config fields

### DIFF
--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -364,15 +364,96 @@ func MigrateTrustedProxyConfig(cmd *cobra.Command, cwd string, _, _ *semver.Vers
 // in Fiber v3. It renames Prefork and Network fields and adapts them to the new
 // listener configuration fields.
 func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	var disableStartup string
+	var enablePrint string
+
 	err := internal.ChangeFileContent(cwd, func(content string) string {
 		replacer := strings.NewReplacer(
 			"Prefork:", "EnablePrefork:",
 			"Network:", "ListenerNetwork:",
 		)
-		return replacer.Replace(content)
+		content = replacer.Replace(content)
+
+		reStartup := regexp.MustCompile(`(?m)^\s*DisableStartupMessage:\s*([^,]+),?\n`)
+		content = reStartup.ReplaceAllStringFunc(content, func(s string) string {
+			if disableStartup == "" {
+				sub := reStartup.FindStringSubmatch(s)
+				if len(sub) > 1 {
+					disableStartup = strings.TrimSpace(sub[1])
+				}
+			}
+			return ""
+		})
+
+		rePrint := regexp.MustCompile(`(?m)^\s*EnablePrintRoutes:\s*([^,]+),?\n`)
+		content = rePrint.ReplaceAllStringFunc(content, func(s string) string {
+			if enablePrint == "" {
+				sub := rePrint.FindStringSubmatch(s)
+				if len(sub) > 1 {
+					enablePrint = strings.TrimSpace(sub[1])
+				}
+			}
+			return ""
+		})
+
+		return content
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate listener related config fields: %w", err)
+	}
+
+	err = internal.ChangeFileContent(cwd, func(content string) string {
+		if disableStartup == "" && enablePrint == "" {
+			return content
+		}
+
+		reWithCfg := regexp.MustCompile(`\.Listen\(([^,]+),\s*fiber.ListenConfig\{([^}]*)\}\)`)
+		content = reWithCfg.ReplaceAllStringFunc(content, func(s string) string {
+			sub := reWithCfg.FindStringSubmatch(s)
+			addr := sub[1]
+			cfg := strings.TrimSpace(sub[2])
+
+			if disableStartup != "" && !strings.Contains(cfg, "DisableStartupMessage:") {
+				if len(cfg) > 0 && !strings.HasSuffix(cfg, ",") {
+					cfg += ","
+				}
+				cfg += " DisableStartupMessage: " + disableStartup + ","
+			}
+			if enablePrint != "" && !strings.Contains(cfg, "EnablePrintRoutes:") {
+				if len(cfg) > 0 && !strings.HasSuffix(cfg, ",") {
+					cfg += ","
+				}
+				cfg += " EnablePrintRoutes: " + enablePrint + ","
+			}
+
+			cfg = strings.TrimSuffix(cfg, ",")
+			return fmt.Sprintf(".Listen(%s, fiber.ListenConfig{%s})", addr, cfg)
+		})
+
+		rePlain := regexp.MustCompile(`\.Listen\(([^,\n)]+)\)`)
+		content = rePlain.ReplaceAllStringFunc(content, func(s string) string {
+			if strings.Contains(s, "fiber.ListenConfig") {
+				return s
+			}
+
+			addr := rePlain.FindStringSubmatch(s)[1]
+			fields := ""
+			if disableStartup != "" {
+				fields += "DisableStartupMessage: " + disableStartup + ", "
+			}
+			if enablePrint != "" {
+				fields += "EnablePrintRoutes: " + enablePrint + ", "
+			}
+			fields = strings.TrimSpace(fields)
+			fields = strings.TrimSuffix(fields, ",")
+
+			return fmt.Sprintf(".Listen(%s, fiber.ListenConfig{%s})", addr, fields)
+		})
+
+		return content
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate listener related listen calls: %w", err)
 	}
 
 	cmd.Println("Migrating listener related config fields")

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -479,23 +479,78 @@ func Test_MigrateConfigListenerFields(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
 
-	file := writeTempFile(t, dir, `package main
+	file1 := filepath.Join(dir, "app.go")
+	require.NoError(t, os.WriteFile(file1, []byte(`package main
 import "github.com/gofiber/fiber/v2"
-func main() {
-    app := fiber.New(fiber.Config{
+func newApp() *fiber.App {
+    return fiber.New(fiber.Config{
         Prefork: true,
         Network: "tcp",
+        DisableStartupMessage: true,
+        EnablePrintRoutes: true,
     })
-    _ = app
-}`)
+}`), 0o600))
+
+	file2 := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(file2, []byte(`package main
+func main() {
+    app := newApp()
+    app.Listen(":3000")
+}`), 0o600))
 
 	var buf bytes.Buffer
 	cmd := newCmd(&buf)
 	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
 
-	content := readFile(t, file)
+	content := readFile(t, file1)
 	assert.Contains(t, content, "EnablePrefork: true")
 	assert.Contains(t, content, "ListenerNetwork: \"tcp\"")
+	assert.NotContains(t, content, "DisableStartupMessage")
+	assert.NotContains(t, content, "EnablePrintRoutes")
+	content2 := readFile(t, file2)
+	assert.Contains(t, content2, "fiber.ListenConfig{")
+	assert.Contains(t, content2, "DisableStartupMessage: true")
+	assert.Contains(t, content2, "EnablePrintRoutes: true")
+	assert.Contains(t, buf.String(), "Migrating listener related config fields")
+}
+
+func Test_MigrateConfigListenerFields_ExistingListenConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mconf2")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file1 := filepath.Join(dir, "app.go")
+	require.NoError(t, os.WriteFile(file1, []byte(`package main
+import "github.com/gofiber/fiber/v2"
+func newApp() *fiber.App {
+    return fiber.New(fiber.Config{
+        DisableStartupMessage: true,
+        EnablePrintRoutes: true,
+    })
+}`), 0o600))
+
+	file2 := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(file2, []byte(`package main
+import "github.com/gofiber/fiber/v2"
+func main() {
+    app := newApp()
+    app.Listen(":3000", fiber.ListenConfig{EnablePrefork: true})
+}`), 0o600))
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
+
+	content1 := readFile(t, file1)
+	assert.NotContains(t, content1, "DisableStartupMessage")
+	assert.NotContains(t, content1, "EnablePrintRoutes")
+
+	content2 := readFile(t, file2)
+	assert.Contains(t, content2, "EnablePrefork: true")
+	assert.Contains(t, content2, "DisableStartupMessage: true")
+	assert.Contains(t, content2, "EnablePrintRoutes: true")
 	assert.Contains(t, buf.String(), "Migrating listener related config fields")
 }
 


### PR DESCRIPTION
## Summary
- collect DisableStartupMessage and EnablePrintRoutes when migrating config
- remove those fields from `fiber.Config` and add them to Listen calls
- test migrating listener settings across multiple files and when ListenConfig already in use

## Testing
- `go test ./...`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0 run ./...` *(fails: can't load config because go1.23 is lower than target 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_6888ca5c6558832686a65efdaf1d37de