### PR TITLE
Add basicauth config migrator

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -59,6 +59,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateSessionExtractor,
 			v3migrations.MigrateTimeoutConfig,
 			v3migrations.MigrateBasicauthAuthorizer,
+			v3migrations.MigrateBasicauthConfig,
 			v3migrations.MigrateReqHeaderParser,
 			MigrateGoVersion("1.24"),
 		},

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -729,7 +729,7 @@ func MigrateBasicauthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version
 	reCtxUser := regexp.MustCompile(`\s*ContextUsername:\s*[^,]+,?\n`)
 	reCtxPass := regexp.MustCompile(`\s*ContextPassword:\s*[^,]+,?\n`)
 	reUsers := regexp.MustCompile(`Users:\s*map\[string\]string{([^}]*)}`)
-	reEntry := regexp.MustCompile(`("[^"]+")\s*:\s*"((?:[^"\\]|\\.)*)"`) 
+	reEntry := regexp.MustCompile(`("[^"]+")\s*:\s*"((?:[^"\\]|\\.)*)"`)
 
 	err := internal.ChangeFileContent(cwd, func(content string) string {
 		content = reCtxUser.ReplaceAllString(content, "")

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -10,6 +12,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gofiber/cli/cmd/internal"
+)
+
+var (
+	hexRe = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+	b64Re = regexp.MustCompile(`^[A-Za-z0-9+/]{43}=?$|^[A-Za-z0-9+/]{44}$`)
 )
 
 func MigrateHandlerSignatures(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
@@ -712,6 +719,50 @@ func MigrateBasicauthAuthorizer(cmd *cobra.Command, cwd string, _, _ *semver.Ver
 	}
 
 	cmd.Println("Migrating basicauth authorizer")
+	return nil
+}
+
+// MigrateBasicauthConfig adapts basicauth configuration to the new API
+// * removes ContextUsername and ContextPassword fields
+// * hashes plaintext Users entries using SHA-256
+func MigrateBasicauthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	reCtxUser := regexp.MustCompile(`\s*ContextUsername:\s*[^,]+,?\n`)
+	reCtxPass := regexp.MustCompile(`\s*ContextPassword:\s*[^,]+,?\n`)
+	reUsers := regexp.MustCompile(`Users:\s*map\[string\]string{([^}]*)}`)
+	reEntry := regexp.MustCompile(`("[^"]+")\s*:\s*"([^"]*)"`)
+
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		content = reCtxUser.ReplaceAllString(content, "")
+		content = reCtxPass.ReplaceAllString(content, "")
+
+		content = reUsers.ReplaceAllStringFunc(content, func(m string) string {
+			sub := reUsers.FindStringSubmatch(m)
+			if len(sub) < 2 {
+				return m
+			}
+			body := reEntry.ReplaceAllStringFunc(sub[1], func(s string) string {
+				es := reEntry.FindStringSubmatch(s)
+				if len(es) < 3 {
+					return s
+				}
+				pwd := es[2]
+				if strings.HasPrefix(pwd, "{") || strings.HasPrefix(pwd, "$2") || hexRe.MatchString(pwd) || b64Re.MatchString(pwd) {
+					return s
+				}
+				sum := sha256.Sum256([]byte(pwd))
+				hashed := base64.StdEncoding.EncodeToString(sum[:])
+				return fmt.Sprintf("%s: \"{SHA256}%s\"", es[1], hashed)
+			})
+			return "Users: map[string]string{" + body + "}"
+		})
+
+		return content
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate basicauth config: %w", err)
+	}
+
+	cmd.Println("Migrating basicauth configs")
 	return nil
 }
 

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	hexRe = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
-	b64Re = regexp.MustCompile(`^[A-Za-z0-9+/]{43}=?$|^[A-Za-z0-9+/]{44}$`)
+	b64Re = regexp.MustCompile(`^[A-Za-z0-9+/]{43}=?$`)
 )
 
 func MigrateHandlerSignatures(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -729,7 +729,7 @@ func MigrateBasicauthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version
 	reCtxUser := regexp.MustCompile(`\s*ContextUsername:\s*[^,]+,?\n`)
 	reCtxPass := regexp.MustCompile(`\s*ContextPassword:\s*[^,]+,?\n`)
 	reUsers := regexp.MustCompile(`Users:\s*map\[string\]string{([^}]*)}`)
-	reEntry := regexp.MustCompile(`("[^"]+")\s*:\s*"([^"]*)"`)
+	reEntry := regexp.MustCompile(`("[^"]+")\s*:\s*"((?:[^"\\]|\\.)*)"`) 
 
 	err := internal.ChangeFileContent(cwd, func(content string) string {
 		content = reCtxUser.ReplaceAllString(content, "")

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -883,6 +883,35 @@ var _ = basicauth.New(basicauth.Config{
 	assert.Contains(t, buf.String(), "Migrating basicauth authorizer")
 }
 
+func Test_MigrateBasicauthConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mbasiccfg")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2"
+    "github.com/gofiber/fiber/v2/middleware/basicauth"
+)
+var _ = basicauth.New(basicauth.Config{
+    Users: map[string]string{"john": "doe"},
+    ContextUsername: "u",
+    ContextPassword: "p",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateBasicauthConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "ContextUsername")
+	assert.NotContains(t, content, "ContextPassword")
+	assert.Contains(t, content, "{SHA256}eZ75KhGvkY4/t0HfQpNPO1aO0tk6wd908bjUGieTKm8=")
+	assert.Contains(t, buf.String(), "Migrating basicauth configs")
+}
+
 func Test_MigrateShutdownHook(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add `MigrateBasicauthConfig` to update BasicAuth middleware configuration
- register the new migrator
- test the new migration behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889c02a83288326bc5a0e3a60bd8c86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved migration process for basicauth middleware configurations, including automatic removal of deprecated fields and secure hashing of user passwords.
* **Bug Fixes**
  * Enhanced handling of basicauth configuration to ensure deprecated fields are properly removed and plaintext passwords are securely updated.
* **Tests**
  * Added tests to verify correct migration of basicauth configurations, ensuring deprecated fields are removed and passwords are hashed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->