### PR TITLE
Update Test migration for disabled timeout

### DIFF
--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -631,7 +631,17 @@ func MigrateTimeoutConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) 
 func MigrateAppTestConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	err := internal.ChangeFileContent(cwd, func(content string) string {
 		re := regexp.MustCompile(`\.Test\(([^,\n]+),\s*([^\n)]+)\)`)
-		return re.ReplaceAllString(content, `.Test($1, fiber.TestConfig{Timeout: $2})`)
+		return re.ReplaceAllStringFunc(content, func(m string) string {
+			sub := re.FindStringSubmatch(m)
+			if len(sub) < 3 {
+				return m
+			}
+			arg := strings.TrimSpace(sub[2])
+			if arg == "-1" {
+				return fmt.Sprintf(".Test(%s, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})", sub[1])
+			}
+			return fmt.Sprintf(".Test(%s, fiber.TestConfig{Timeout: %s})", sub[1], arg)
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate app.Test calls: %w", err)

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -760,6 +760,33 @@ func main() {
 	assert.Contains(t, buf.String(), "Migrating app.Test usages")
 }
 
+func Test_MigrateAppTestConfig_DisableTimeout(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mtestcfg")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2"
+    "net/http/httptest"
+)
+func main() {
+    app := fiber.New()
+    req := httptest.NewRequest(fiber.MethodGet, "/", nil)
+    _ = app.Test(req, -1)
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateAppTestConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `app.Test(req, fiber.TestConfig{Timeout: 0, FailOnTimeout: false})`)
+	assert.Contains(t, buf.String(), "Migrating app.Test usages")
+}
+
 func Test_MigrateMiddlewareLocals(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- update `MigrateAppTestConfig` to convert `app.Test(req, -1)` into the new `TestConfig`
- add test covering negative timeout migration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b75b64bf4832693df3e731cba8d2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of test timeout values, ensuring that a timeout of "-1" now correctly disables timeouts without causing test failures.

* **Tests**
  * Added new tests to verify the correct migration of test calls when the timeout is set to "-1".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->