### PR TITLE
Add migrator for removed StorePassword

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -60,6 +60,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateTimeoutConfig,
 			v3migrations.MigrateBasicauthAuthorizer,
 			v3migrations.MigrateBasicauthConfig,
+			v3migrations.MigrateBasicauthStorePassword,
 			v3migrations.MigrateReqHeaderParser,
 			MigrateGoVersion("1.24"),
 		},

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -775,6 +775,21 @@ func MigrateBasicauthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version
 	return nil
 }
 
+// MigrateBasicauthStorePassword comments usages of the removed StorePassword option
+// in basicauth middleware configuration.
+func MigrateBasicauthStorePassword(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	re := regexp.MustCompile(`(\s*)StorePassword:\s*([^,\n]+)(,?)`)
+	err := internal.ChangeFileContent(cwd, func(content string) string {
+		return re.ReplaceAllString(content, `$1// TODO: StorePassword removed ($2)$3`)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate basicauth StorePassword: %w", err)
+	}
+
+	cmd.Println("Migrating basicauth StorePassword option")
+	return nil
+}
+
 // MigrateCacheConfig updates cache middleware configuration fields
 func MigrateCacheConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	err := internal.ChangeFileContent(cwd, func(content string) string {

--- a/cmd/internal/migrations/v3/common_test.go
+++ b/cmd/internal/migrations/v3/common_test.go
@@ -1031,6 +1031,32 @@ var _ = basicauth.New(basicauth.Config{
 	assert.Contains(t, buf.String(), "Migrating basicauth configs")
 }
 
+func Test_MigrateBasicauthStorePassword(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mbasicstore")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2"
+    "github.com/gofiber/fiber/v2/middleware/basicauth"
+)
+var _ = basicauth.New(basicauth.Config{
+    StorePassword: true,
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateBasicauthStorePassword(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "StorePassword:")
+	assert.Contains(t, content, "// TODO: StorePassword removed (true)")
+	assert.Contains(t, buf.String(), "Migrating basicauth StorePassword option")
+}
+
 func Test_MigrateShutdownHook(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add migration helper to comment out removed `StorePassword` option
- include new migrator in migration list
- test that the migrator comments out the field

## Testing
- `go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -shuffle=on`

------
https://chatgpt.com/codex/tasks/task_e_688c9bbe30a88326b43d494955195944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration now automatically comments out deprecated `StorePassword` options in basicauth configurations, adding a TODO note for user review.

* **Tests**
  * Added tests to verify that deprecated `StorePassword` options are properly handled and users are notified during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->