### PR TITLE
chore: set Go 1.25 as minimum for v3

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,7 +29,7 @@ jobs:
             - uses: actions/setup-go@v5
               with:
                   # NOTE: Keep this in sync with the version from go.mod
-                  go-version: "1.24.x"
+                  go-version: "1.25.x"
                   cache: false
 
             - name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fiber Command Line Interface
 
 ## Installation
 
-Requires Go 1.24 or later.
+Requires Go 1.25 or later.
 
 ```bash
 go install github.com/gofiber/cli/fiber@latest

--- a/cmd/internal/migrations/go_version_test.go
+++ b/cmd/internal/migrations/go_version_test.go
@@ -46,12 +46,12 @@ require github.com/gofiber/fiber/v2 v2.0.0`
 
 	var buf bytes.Buffer
 	cmd := newCmd(&buf)
-	fn := migrations.MigrateGoVersion("1.23")
+	fn := migrations.MigrateGoVersion("1.25")
 	require.NoError(t, fn(cmd, dir, nil, nil))
 
 	content := readFile(t, filepath.Join(dir, "go.mod"))
-	assert.Contains(t, content, "go 1.23")
-	assert.Contains(t, buf.String(), "1.23")
+	assert.Contains(t, content, "go 1.25")
+	assert.Contains(t, buf.String(), "1.25")
 
 	vendorContent := readFile(t, filepath.Join(vendor, "go.mod"))
 	assert.Contains(t, vendorContent, "go 1.10")

--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -62,7 +62,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateBasicauthConfig,
 			v3migrations.MigrateBasicauthStorePassword,
 			v3migrations.MigrateReqHeaderParser,
-			MigrateGoVersion("1.24"),
+			MigrateGoVersion("1.25"),
 		},
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/cli
 
-go 1.24
+go 1.25
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary
- require Go 1.25 or later
- update migrations and CI to 1.25

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bb0014f3883268520f4519c55a990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Requirements
  - Raised minimum supported Go version to 1.25.
- Documentation
  - Updated installation instructions to state Go 1.25 or later.
- Tests
  - Aligned migration tests with the new Go version requirement.
- Chores
  - Updated migration configuration to target Go 1.25 in the upgrade path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->