### PR TITLE
Remove CSRF ContextKey and streamline TokenFromContext usage

### DIFF
--- a/cmd/internal/migrations/v3/csrfconfig.go
+++ b/cmd/internal/migrations/v3/csrfconfig.go
@@ -15,12 +15,14 @@ import (
 func MigrateCSRFConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	reConfig := regexp.MustCompile(`csrf\.Config{[^}]*}`)
 	reSession := regexp.MustCompile(`\s*SessionKey:\s*[^,]+,?\n`)
+	reContextKey := regexp.MustCompile(`\s*ContextKey:\s*[^,]+,?\n`)
 	reKeyLookup := regexp.MustCompile(`(\s*)KeyLookup:\s*([^,\n]+)(,?)(\n?)`)
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
 		content = reConfig.ReplaceAllStringFunc(content, func(s string) string {
 			return strings.ReplaceAll(s, "Expiration:", "IdleTimeout:")
 		})
 		content = reSession.ReplaceAllString(content, "")
+		content = reContextKey.ReplaceAllString(content, "")
 
 		content = reKeyLookup.ReplaceAllStringFunc(content, func(s string) string {
 			sub := reKeyLookup.FindStringSubmatch(s)

--- a/cmd/internal/migrations/v3/csrfconfig_test.go
+++ b/cmd/internal/migrations/v3/csrfconfig_test.go
@@ -26,6 +26,7 @@ import (
 var _ = csrf.New(csrf.Config{
     Expiration: 10 * time.Minute,
     SessionKey: "csrf",
+    ContextKey: "csrf",
 })`)
 
 	var buf bytes.Buffer
@@ -36,6 +37,7 @@ var _ = csrf.New(csrf.Config{
 	assert.Contains(t, content, "IdleTimeout:")
 	assert.NotContains(t, content, "Expiration:")
 	assert.NotContains(t, content, "SessionKey")
+	assert.NotContains(t, content, "ContextKey")
 	assert.Contains(t, buf.String(), "Migrating CSRF middleware configs")
 }
 

--- a/cmd/internal/migrations/v3/middleware_locals.go
+++ b/cmd/internal/migrations/v3/middleware_locals.go
@@ -27,6 +27,13 @@ func MigrateMiddlewareLocals(cmd *cobra.Command, cwd string, _, _ *semver.Versio
 		for _, r := range replacements {
 			content = r.re.ReplaceAllString(content, r.repl)
 		}
+
+		reTypeAssert := regexp.MustCompile(`([\w\.]+FromContext\([^\)]+\))\.\([^\)]+\)`)
+		content = reTypeAssert.ReplaceAllString(content, "$1")
+
+		reComma := regexp.MustCompile(`(\w+)\s*,\s*\w+\s*:=\s*([\w\.]+FromContext\([^\)]+\))`)
+		content = reComma.ReplaceAllString(content, "$1 := $2")
+
 		return content
 	})
 	if err != nil {

--- a/cmd/internal/migrations/v3/middleware_locals_test.go
+++ b/cmd/internal/migrations/v3/middleware_locals_test.go
@@ -21,8 +21,12 @@ func Test_MigrateMiddlewareLocals(t *testing.T) {
 	file := writeTempFile(t, dir, `package main
 import "github.com/gofiber/fiber/v2"
 func handler(c fiber.Ctx) error {
-    id := c.Locals("requestid")
+    id := c.Locals("requestid").(string)
+    csrfToken, _ := c.Locals("csrf").(string)
+    token := c.Locals("token").(string)
     _ = id
+    _ = csrfToken
+    _ = token
     return nil
 }`)
 
@@ -31,6 +35,8 @@ func handler(c fiber.Ctx) error {
 	require.NoError(t, v3.MigrateMiddlewareLocals(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.Contains(t, content, `requestid.FromContext(c)`)
+	assert.Contains(t, content, `id := requestid.FromContext(c)`)
+	assert.Contains(t, content, `csrfToken := csrf.TokenFromContext(c)`)
+	assert.Contains(t, content, `token := keyauth.TokenFromContext(c)`)
 	assert.Contains(t, buf.String(), "Migrating middleware locals")
 }


### PR DESCRIPTION
## Summary
- drop deprecated `ContextKey` from CSRF config migration
- simplify middleware locals by removing type assertions and extra return values when using `TokenFromContext`
- add tests for updated CSRF config and middleware locals migrations

## Testing
- `make lint` *(fails: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.25))*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9d2363da083269901679cf359c323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

• New Features
  • Improved v3 migration produces cleaner CSRF configs by removing deprecated fields and standardizing timeouts and key lookups.

• Bug Fixes
  • Ensures outdated CSRF settings are fully removed during migration, avoiding leftover, unused options.

• Refactor
  • Post-processing now strips unnecessary type assertions and simplifies assignments in migrated middleware code for better readability and compatibility.

• Tests
  • Expanded migration tests to validate CSRF field removals, timeout renaming, key lookup normalization, and middleware code cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->