### PR TITLE
Guard ViewBind migration with Fiber context check

### DIFF
--- a/cmd/internal/migrations/v3/view_bind.go
+++ b/cmd/internal/migrations/v3/view_bind.go
@@ -11,11 +11,22 @@ import (
 )
 
 func MigrateViewBind(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
-	// Replace .Bind() with arguments, not the Bind() from the binding package
-	reViewBind := regexp.MustCompile(`\.Bind\(([^)]+)\)`)
+	reViewBind := regexp.MustCompile(`(\w+)\.Bind\(([^)]+)\)`)
 
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
-		return reViewBind.ReplaceAllString(content, ".ViewBind($1)")
+		orig := content
+		return reViewBind.ReplaceAllStringFunc(content, func(match string) string {
+			parts := reViewBind.FindStringSubmatch(match)
+			if len(parts) != 3 {
+				return match
+			}
+			ident := parts[1]
+			args := parts[2]
+			if isFiberCtx(orig, ident) {
+				return ident + ".ViewBind(" + args + ")"
+			}
+			return match
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate ViewBind calls: %w", err)

--- a/cmd/internal/migrations/v3/view_bind_test.go
+++ b/cmd/internal/migrations/v3/view_bind_test.go
@@ -33,3 +33,25 @@ func handler(c fiber.Ctx) error {
 	assert.NotContains(t, content, "c.Bind(")
 	assert.Contains(t, buf.String(), "Migrating view binding helpers")
 }
+
+func Test_MigrateViewBind_NoChange(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mvbtest")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+func handler() {
+    queries.Bind(results, &resultSlice)
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateViewBind(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "queries.Bind(")
+	assert.NotContains(t, content, "ViewBind(")
+	assert.Empty(t, buf.String())
+}


### PR DESCRIPTION
## Summary
- Ensure ViewBind migration only rewrites Bind calls on Fiber contexts
- Add regression test to avoid changing non-Fiber Bind usages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a9d82d86008326aad3f5d43f4727e2