### PR TITLE
fix: migrate listener fields to ListenConfig

### DIFF
--- a/cmd/internal/migrations/v3/config_listener_fields.go
+++ b/cmd/internal/migrations/v3/config_listener_fields.go
@@ -12,45 +12,60 @@ import (
 )
 
 func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	var enablePrefork string
+	var listenerNetwork string
 	var disableStartup string
 	var enablePrint string
 
+	reField := regexp.MustCompile(`\s*(Prefork|Network|DisableStartupMessage|EnablePrintRoutes):\s*([^,}]+),?`)
 	changed1, err := internal.ChangeFileContent(cwd, func(content string) string {
-		rePrefork := regexp.MustCompile(`(?m)^(\s*)Prefork:`)
-		content = rePrefork.ReplaceAllString(content, `${1}EnablePrefork:`)
-		reNetwork := regexp.MustCompile(`(?m)^(\s*)Network:`)
-		content = reNetwork.ReplaceAllString(content, `${1}ListenerNetwork:`)
-
-		reStartup := regexp.MustCompile(`(?m)^\s*DisableStartupMessage:\s*([^,]+),?\n`)
-		content = reStartup.ReplaceAllStringFunc(content, func(s string) string {
-			if disableStartup == "" {
-				sub := reStartup.FindStringSubmatch(s)
-				if len(sub) > 1 {
-					disableStartup = strings.TrimSpace(sub[1])
+		reConfig := regexp.MustCompile(`fiber\.Config\{[^}]*\}`)
+		return reConfig.ReplaceAllStringFunc(content, func(cfg string) string {
+			inner := cfg[len("fiber.Config{") : len(cfg)-1]
+			inner = reField.ReplaceAllStringFunc(inner, func(f string) string {
+				sub := reField.FindStringSubmatch(f)
+				if len(sub) == 3 {
+					name := sub[1]
+					val := strings.TrimSpace(sub[2])
+					switch name {
+					case "Prefork":
+						if enablePrefork == "" {
+							enablePrefork = val
+						}
+					case "Network":
+						if listenerNetwork == "" {
+							listenerNetwork = val
+						}
+					case "DisableStartupMessage":
+						if disableStartup == "" {
+							disableStartup = val
+						}
+					case "EnablePrintRoutes":
+						if enablePrint == "" {
+							enablePrint = val
+						}
+					}
+					return ""
 				}
+				return f
+			})
+			inner = regexp.MustCompile(`,\s*,`).ReplaceAllString(inner, ",")
+			inner = strings.TrimSpace(inner)
+			inner = strings.TrimPrefix(inner, ",")
+			inner = strings.TrimSuffix(inner, ",")
+			inner = strings.TrimSpace(inner)
+			if inner == "" {
+				return "fiber.Config{}"
 			}
-			return ""
+			return "fiber.Config{" + inner + "}"
 		})
-
-		rePrint := regexp.MustCompile(`(?m)^\s*EnablePrintRoutes:\s*([^,]+),?\n`)
-		content = rePrint.ReplaceAllStringFunc(content, func(s string) string {
-			if enablePrint == "" {
-				sub := rePrint.FindStringSubmatch(s)
-				if len(sub) > 1 {
-					enablePrint = strings.TrimSpace(sub[1])
-				}
-			}
-			return ""
-		})
-
-		return content
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate listener related config fields: %w", err)
 	}
 
 	changed2, err := internal.ChangeFileContent(cwd, func(content string) string {
-		if disableStartup == "" && enablePrint == "" {
+		if enablePrefork == "" && listenerNetwork == "" && disableStartup == "" && enablePrint == "" {
 			return content
 		}
 
@@ -61,6 +76,18 @@ func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Ve
 			if len(args) == 2 && strings.Contains(args[1], "fiber.ListenConfig") {
 				cfg := strings.TrimPrefix(args[1], "fiber.ListenConfig{")
 				cfg = strings.TrimSuffix(cfg, "}")
+				if enablePrefork != "" && !strings.Contains(cfg, "EnablePrefork:") {
+					if len(strings.TrimSpace(cfg)) > 0 {
+						cfg += ","
+					}
+					cfg += " EnablePrefork: " + enablePrefork
+				}
+				if listenerNetwork != "" && !strings.Contains(cfg, "ListenerNetwork:") {
+					if len(strings.TrimSpace(cfg)) > 0 {
+						cfg += ","
+					}
+					cfg += " ListenerNetwork: " + listenerNetwork
+				}
 				if disableStartup != "" && !strings.Contains(cfg, "DisableStartupMessage:") {
 					if len(strings.TrimSpace(cfg)) > 0 {
 						cfg += ","
@@ -78,15 +105,20 @@ func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Ve
 			}
 
 			if len(args) == 1 {
-				fields := ""
+				var fields []string
+				if enablePrefork != "" {
+					fields = append(fields, "EnablePrefork: "+enablePrefork)
+				}
+				if listenerNetwork != "" {
+					fields = append(fields, "ListenerNetwork: "+listenerNetwork)
+				}
 				if disableStartup != "" {
-					fields += "DisableStartupMessage: " + disableStartup + ", "
+					fields = append(fields, "DisableStartupMessage: "+disableStartup)
 				}
 				if enablePrint != "" {
-					fields += "EnablePrintRoutes: " + enablePrint + ", "
+					fields = append(fields, "EnablePrintRoutes: "+enablePrint)
 				}
-				fields = strings.TrimSuffix(strings.TrimSpace(fields), ",")
-				return fmt.Sprintf(".Listen(%s, fiber.ListenConfig{%s})", args[0], fields)
+				return fmt.Sprintf(".Listen(%s, fiber.ListenConfig{%s})", args[0], strings.Join(fields, ", "))
 			}
 
 			return call
@@ -102,5 +134,3 @@ func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Ve
 	cmd.Println("Migrating listener related config fields")
 	return nil
 }
-
-// ListenerConfig. Fiber v3 replaces these with the OnPostShutdown hook.

--- a/cmd/internal/migrations/v3/config_listener_fields_test.go
+++ b/cmd/internal/migrations/v3/config_listener_fields_test.go
@@ -43,12 +43,14 @@ func main() {
 	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
 
 	content := readFile(t, file1)
-	assert.Contains(t, content, "EnablePrefork:   true")
-	assert.Contains(t, content, "ListenerNetwork: \"tcp\"")
+	assert.NotContains(t, content, "Prefork")
+	assert.NotContains(t, content, "Network")
 	assert.NotContains(t, content, "DisableStartupMessage")
 	assert.NotContains(t, content, "EnablePrintRoutes")
 	content2 := readFile(t, file2)
 	assert.Contains(t, content2, "fiber.ListenConfig{")
+	assert.Contains(t, content2, "EnablePrefork: true")
+	assert.Contains(t, content2, "ListenerNetwork: \"tcp\"")
 	assert.Contains(t, content2, "DisableStartupMessage: true")
 	assert.Contains(t, content2, "EnablePrintRoutes: true")
 	assert.Contains(t, buf.String(), "Migrating listener related config fields")
@@ -66,6 +68,8 @@ func Test_MigrateConfigListenerFields_ExistingListenConfig(t *testing.T) {
 import "github.com/gofiber/fiber/v2"
 func newApp() *fiber.App {
     return fiber.New(fiber.Config{
+        Prefork: true,
+        Network: "tcp",
         DisableStartupMessage: true,
         EnablePrintRoutes: true,
     })
@@ -84,11 +88,14 @@ func main() {
 	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
 
 	content1 := readFile(t, file1)
+	assert.NotContains(t, content1, "Prefork")
+	assert.NotContains(t, content1, "Network")
 	assert.NotContains(t, content1, "DisableStartupMessage")
 	assert.NotContains(t, content1, "EnablePrintRoutes")
 
 	content2 := readFile(t, file2)
 	assert.Contains(t, content2, "EnablePrefork: true")
+	assert.Contains(t, content2, "ListenerNetwork: \"tcp\"")
 	assert.Contains(t, content2, "DisableStartupMessage: true")
 	assert.Contains(t, content2, "EnablePrintRoutes: true")
 	assert.Contains(t, buf.String(), "Migrating listener related config fields")
@@ -168,4 +175,56 @@ func main() {
 	second2 := readFile(t, file2)
 	assert.Equal(t, first1, second1)
 	assert.Equal(t, first2, second2)
+}
+
+func Test_MigrateConfigListenerFields_SingleFile(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mconf_single")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2"
+func main() {
+    app := fiber.New(fiber.Config{
+        Prefork: true,
+        Network: "tcp",
+        DisableStartupMessage: true,
+        EnablePrintRoutes: true,
+    })
+    app.Listen(":3000")
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "fiber.ListenConfig{EnablePrefork: true, ListenerNetwork: \"tcp\", DisableStartupMessage: true, EnablePrintRoutes: true}")
+	assert.Contains(t, buf.String(), "Migrating listener related config fields")
+}
+
+func Test_MigrateConfigListenerFields_InlineConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mconf_inline")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2"
+func main() {
+    app := fiber.New(fiber.Config{DisableStartupMessage: true})
+    go app.Listen(":3000")
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "fiber.New(fiber.Config{})")
+	assert.Contains(t, content, `go app.Listen(":3000", fiber.ListenConfig{DisableStartupMessage: true})`)
+	assert.Contains(t, buf.String(), "Migrating listener related config fields")
 }


### PR DESCRIPTION
## Summary
- handle listener fields declared inline in `fiber.Config` and migrate them to `fiber.ListenConfig`
- add regression test covering inline config and goroutine listener
- remove leftover assignments from listener field migration so `golangci-lint` passes

## Testing
- `go test ./...`
- `GOTOOLCHAIN=go1.25.0 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0 -v run ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a9d0106ffc83269e722ca2e6a1f99a