### PR TITLE
Fix migration verbose output

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -1,7 +1,12 @@
 package migrations
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"reflect"
+	"runtime"
+	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
@@ -71,6 +76,14 @@ var Migrations = []Migration{
 	},
 }
 
+func migrationName(fn MigrationFn) string {
+	f := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	if idx := strings.LastIndex(f, "."); idx >= 0 {
+		return f[idx+1:]
+	}
+	return f
+}
+
 // DoMigration runs all migrations
 // It will run all migrations that match the current and target version
 func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, skipGoMod, verbose bool) error {
@@ -86,8 +99,25 @@ func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, s
 
 		if fromC.Check(curr) && toC.Check(target) {
 			for _, fn := range m.Functions {
-				if err := fn(cmd, cwd, curr, target); err != nil {
-					return err
+				if verbose {
+					var buf bytes.Buffer
+					origOut := cmd.OutOrStdout()
+					cmd.SetOut(io.MultiWriter(origOut, &buf))
+					err := fn(cmd, cwd, curr, target)
+					cmd.SetOut(origOut)
+					name := migrationName(fn)
+					if buf.Len() == 0 {
+						cmd.Printf("%s: no changes\n", name)
+					} else {
+						cmd.Printf("%s: changed\n", name)
+					}
+					if err != nil {
+						return err
+					}
+				} else {
+					if err := fn(cmd, cwd, curr, target); err != nil {
+						return err
+					}
 				}
 			}
 		} else if verbose {

--- a/cmd/internal/migrations/lists_test.go
+++ b/cmd/internal/migrations/lists_test.go
@@ -2,6 +2,8 @@ package migrations_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -37,6 +39,42 @@ func Test_DoMigration_Verbose(t *testing.T) {
 		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true))
 		out := buf.String()
 		assert.Contains(t, out, "Skipping migration from >=1.0.0 to >=0.0.0-0")
+		assert.Contains(t, out, "Skipping migration from >=2.0.0 to <4.0.0-0")
+	})
+}
+
+func Test_DoMigration_Verbose_Run(t *testing.T) {
+	t.Parallel()
+	curr := semver.MustParse("1.0.0")
+	target := semver.MustParse("2.0.0")
+
+	t.Run("no changes", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n\nrequire github.com/gofiber/fiber/v2 v2.0.0\n"), 0o600))
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true))
+		out := buf.String()
+		assert.Contains(t, out, "MigrateGoPkgs: no changes")
+		assert.Contains(t, out, "Skipping migration from >=2.0.0 to <4.0.0-0")
+	})
+
+	t.Run("changes", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n\nrequire github.com/gofiber/fiber/v1 v1.0.0\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\nimport \"github.com/gofiber/fiber/v1\"\n"), 0o600))
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true))
+		out := buf.String()
+		assert.Contains(t, out, "Migrating Go packages")
+		assert.Contains(t, out, "MigrateGoPkgs: changed")
 		assert.Contains(t, out, "Skipping migration from >=2.0.0 to <4.0.0-0")
 	})
 }


### PR DESCRIPTION
## Summary
- show change status for each migrator when verbose
- test verbose migration output for changed and unchanged cases

## Testing
- `make lint` *(fails: Interrupt)*
- `GOTOOLCHAIN=go1.25.0 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0 run ./cmd/internal/migrations`
- `make test` *(fails: Interrupt)*
- `go test ./cmd/internal/migrations -run Test_DoMigration_Verbose_Run -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a9f25b85dc832691337febd54ab093