### PR TITLE
migrate keyauth config

### DIFF
--- a/cmd/internal/migrations/v3/csrfconfig.go
+++ b/cmd/internal/migrations/v3/csrfconfig.go
@@ -15,14 +15,12 @@ import (
 func MigrateCSRFConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	reConfig := regexp.MustCompile(`csrf\.Config{[^}]*}`)
 	reSession := regexp.MustCompile(`\s*SessionKey:\s*[^,]+,?\n`)
-	reContextKey := regexp.MustCompile(`\s*ContextKey:\s*[^,]+,?\n`)
 	reKeyLookup := regexp.MustCompile(`(\s*)KeyLookup:\s*([^,\n]+)(,?)(\n?)`)
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
 		content = reConfig.ReplaceAllStringFunc(content, func(s string) string {
 			return strings.ReplaceAll(s, "Expiration:", "IdleTimeout:")
 		})
 		content = reSession.ReplaceAllString(content, "")
-		content = reContextKey.ReplaceAllString(content, "")
 
 		content = reKeyLookup.ReplaceAllStringFunc(content, func(s string) string {
 			sub := reKeyLookup.FindStringSubmatch(s)

--- a/cmd/internal/migrations/v3/csrfconfig_test.go
+++ b/cmd/internal/migrations/v3/csrfconfig_test.go
@@ -26,7 +26,6 @@ import (
 var _ = csrf.New(csrf.Config{
     Expiration: 10 * time.Minute,
     SessionKey: "csrf",
-    ContextKey: "csrf",
 })`)
 
 	var buf bytes.Buffer
@@ -37,7 +36,6 @@ var _ = csrf.New(csrf.Config{
 	assert.Contains(t, content, "IdleTimeout:")
 	assert.NotContains(t, content, "Expiration:")
 	assert.NotContains(t, content, "SessionKey")
-	assert.NotContains(t, content, "ContextKey")
 	assert.Contains(t, buf.String(), "Migrating CSRF middleware configs")
 }
 

--- a/cmd/internal/migrations/v3/key_auth_config.go
+++ b/cmd/internal/migrations/v3/key_auth_config.go
@@ -20,69 +20,71 @@ func MigrateKeyAuthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) 
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
 		return reConfig.ReplaceAllStringFunc(content, func(cfg string) string {
 			keyMatch := reKeyLookup.FindStringSubmatch(cfg)
-			if len(keyMatch) < 5 {
-				// remove AuthScheme if present
-				return removeConfigField(cfg, "AuthScheme")
-			}
+			if len(keyMatch) == 5 {
+				indent := keyMatch[1]
+				val := strings.TrimSpace(keyMatch[2])
+				comma := keyMatch[3]
+				newline := keyMatch[4]
 
-			indent := keyMatch[1]
-			val := strings.TrimSpace(keyMatch[2])
-			comma := keyMatch[3]
-			newline := keyMatch[4]
-
-			if uq, err := strconv.Unquote(val); err == nil {
-				val = uq
-			}
-
-			scheme := "Bearer"
-			if am := reAuthScheme.FindStringSubmatch(cfg); len(am) > 1 {
-				scheme = strings.TrimSpace(am[1])
-				if uq, err := strconv.Unquote(scheme); err == nil {
-					scheme = uq
+				if uq, err := strconv.Unquote(val); err == nil {
+					val = uq
 				}
-			}
 
-			parts := strings.Split(val, ",")
-			var extractors []string
-			for _, p := range parts {
-				p = strings.TrimSpace(p)
-				switch {
-				case strings.HasPrefix(p, "header:"):
-					header := strings.TrimPrefix(p, "header:")
-					if strings.EqualFold(header, "Authorization") {
-						extractors = append(extractors, fmt.Sprintf("keyauth.FromAuthHeader(%q, %q)", header, scheme))
-					} else {
-						extractors = append(extractors, fmt.Sprintf("keyauth.FromHeader(%q)", header))
+				scheme := "Bearer"
+				if am := reAuthScheme.FindStringSubmatch(cfg); len(am) > 1 {
+					scheme = strings.TrimSpace(am[1])
+					if uq, err := strconv.Unquote(scheme); err == nil {
+						scheme = uq
 					}
-				case strings.HasPrefix(p, "query:"):
-					extractors = append(extractors, fmt.Sprintf("keyauth.FromQuery(%q)", strings.TrimPrefix(p, "query:")))
-				case strings.HasPrefix(p, "param:"):
-					extractors = append(extractors, fmt.Sprintf("keyauth.FromParam(%q)", strings.TrimPrefix(p, "param:")))
-				case strings.HasPrefix(p, "form:"):
-					extractors = append(extractors, fmt.Sprintf("keyauth.FromForm(%q)", strings.TrimPrefix(p, "form:")))
-				case strings.HasPrefix(p, "cookie:"):
-					extractors = append(extractors, fmt.Sprintf("keyauth.FromCookie(%q)", strings.TrimPrefix(p, "cookie:")))
-				default:
-					// unrecognized source; remove field and return
-					cfg = removeConfigField(cfg, "AuthScheme")
-					return removeConfigField(cfg, "KeyLookup")
 				}
+
+				parts := strings.Split(val, ",")
+				var extractors []string
+				for _, p := range parts {
+					p = strings.TrimSpace(p)
+					switch {
+					case strings.HasPrefix(p, "header:"):
+						header := strings.TrimPrefix(p, "header:")
+						if strings.EqualFold(header, "Authorization") {
+							extractors = append(extractors, fmt.Sprintf("keyauth.FromAuthHeader(%q, %q)", header, scheme))
+						} else {
+							extractors = append(extractors, fmt.Sprintf("keyauth.FromHeader(%q)", header))
+						}
+					case strings.HasPrefix(p, "query:"):
+						extractors = append(extractors, fmt.Sprintf("keyauth.FromQuery(%q)", strings.TrimPrefix(p, "query:")))
+					case strings.HasPrefix(p, "param:"):
+						extractors = append(extractors, fmt.Sprintf("keyauth.FromParam(%q)", strings.TrimPrefix(p, "param:")))
+					case strings.HasPrefix(p, "form:"):
+						extractors = append(extractors, fmt.Sprintf("keyauth.FromForm(%q)", strings.TrimPrefix(p, "form:")))
+					case strings.HasPrefix(p, "cookie:"):
+						extractors = append(extractors, fmt.Sprintf("keyauth.FromCookie(%q)", strings.TrimPrefix(p, "cookie:")))
+					default:
+						cfg = removeConfigField(cfg, "AuthScheme")
+						cfg = removeConfigField(cfg, "KeyLookup")
+						return cfg
+					}
+				}
+
+				extractor := ""
+				if len(extractors) == 1 {
+					extractor = extractors[0]
+				} else if len(extractors) > 1 {
+					extractor = fmt.Sprintf("keyauth.Chain(%s)", strings.Join(extractors, ", "))
+				}
+
+				cfg = removeConfigField(cfg, "AuthScheme")
+				if extractor == "" {
+					cfg = removeConfigField(cfg, "KeyLookup")
+					return cfg
+				}
+
+				newField := fmt.Sprintf("%sExtractor: %s%s%s", indent, extractor, comma, newline)
+				cfg = reKeyLookup.ReplaceAllString(cfg, newField)
+				return cfg
 			}
 
-			extractor := ""
-			if len(extractors) == 1 {
-				extractor = extractors[0]
-			} else if len(extractors) > 1 {
-				extractor = fmt.Sprintf("keyauth.Chain(%s)", strings.Join(extractors, ", "))
-			}
-
+			cfg = removeConfigField(cfg, "KeyLookup")
 			cfg = removeConfigField(cfg, "AuthScheme")
-			if extractor == "" {
-				return removeConfigField(cfg, "KeyLookup")
-			}
-
-			newField := fmt.Sprintf("%sExtractor: %s%s%s", indent, extractor, comma, newline)
-			cfg = reKeyLookup.ReplaceAllString(cfg, newField)
 			return cfg
 		})
 	})

--- a/cmd/internal/migrations/v3/key_auth_config_test.go
+++ b/cmd/internal/migrations/v3/key_auth_config_test.go
@@ -1,0 +1,37 @@
+package v3_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gofiber/cli/cmd/internal/migrations/v3"
+)
+
+func Test_MigrateKeyAuthConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mkeyauth")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/keyauth"
+var _ = keyauth.New(keyauth.Config{
+    KeyLookup: "header:Authorization, query:api",
+    AuthScheme: "Bearer",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateKeyAuthConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.NotContains(t, content, "AuthScheme")
+	assert.Contains(t, content, `Extractor: keyauth.Chain(keyauth.FromAuthHeader("Authorization", "Bearer"), keyauth.FromQuery("api"))`)
+	assert.Contains(t, buf.String(), "Migrating keyauth middleware configs")
+}

--- a/cmd/internal/migrations/v3/middleware_locals.go
+++ b/cmd/internal/migrations/v3/middleware_locals.go
@@ -34,6 +34,9 @@ func MigrateMiddlewareLocals(cmd *cobra.Command, cwd string, _, _ *semver.Versio
 		reComma := regexp.MustCompile(`(\w+)\s*,\s*\w+\s*:=\s*([\w\.]+FromContext\([^\)]+\))`)
 		content = reComma.ReplaceAllString(content, "$1 := $2")
 
+		reCtxKey := regexp.MustCompile(`\s*ContextKey:\s*[^,}\n]+,?`)
+		content = reCtxKey.ReplaceAllString(content, "")
+
 		return content
 	})
 	if err != nil {

--- a/cmd/internal/migrations/v3/middleware_locals_test.go
+++ b/cmd/internal/migrations/v3/middleware_locals_test.go
@@ -40,3 +40,32 @@ func handler(c fiber.Ctx) error {
 	assert.Contains(t, content, `token := keyauth.TokenFromContext(c)`)
 	assert.Contains(t, buf.String(), "Migrating middleware locals")
 }
+
+func Test_MigrateMiddlewareLocals_ContextKey(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mctxkey")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/keyauth"
+    "github.com/gofiber/fiber/v2/middleware/csrf"
+    "github.com/gofiber/fiber/v2/middleware/session"
+)
+
+func main() {
+    _ = keyauth.New(keyauth.Config{ContextKey: "token"})
+    _ = csrf.New(csrf.Config{ContextKey: "csrf"})
+    _ = session.New(session.Config{ContextKey: "session"})
+}
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateMiddlewareLocals(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "ContextKey")
+}


### PR DESCRIPTION
## Summary
- handle KeyLookup to Extractor migration in keyauth configs
- drop deprecated ContextKey field via middleware locals migrator
- add tests for keyauth and ContextKey migration

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4036b38832696a771c91bf11677