### PR TITLE
Handle two-value assignments in locals and helper migrations

### DIFF
--- a/cmd/internal/migrations/v3/generic_helpers.go
+++ b/cmd/internal/migrations/v3/generic_helpers.go
@@ -11,11 +11,21 @@ import (
 )
 
 func MigrateGenericHelpers(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	reParamsIntAssign := regexp.MustCompile(`(\w+)\s*,\s*(\w+)\s*:=\s*(\w+)\.ParamsInt\(([^)]*)\)`)
+	reQueryIntAssign := regexp.MustCompile(`(\w+)\s*,\s*(\w+)\s*:=\s*(\w+)\.QueryInt\(([^)]*)\)`)
+	reQueryFloatAssign := regexp.MustCompile(`(\w+)\s*,\s*(\w+)\s*:=\s*(\w+)\.QueryFloat\(([^)]*)\)`)
+	reQueryBoolAssign := regexp.MustCompile(`(\w+)\s*,\s*(\w+)\s*:=\s*(\w+)\.QueryBool\(([^)]*)\)`)
+
 	reParamsInt := regexp.MustCompile(`(\w+)\.ParamsInt\(`)
 	reQueryInt := regexp.MustCompile(`(\w+)\.QueryInt\(`)
 	reQueryFloat := regexp.MustCompile(`(\w+)\.QueryFloat\(`)
 	reQueryBool := regexp.MustCompile(`(\w+)\.QueryBool\(`)
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
+		content = reParamsIntAssign.ReplaceAllString(content, "$1, $2 := fiber.Params[int]($3, $4), nil")
+		content = reQueryIntAssign.ReplaceAllString(content, "$1, $2 := fiber.Query[int]($3, $4), nil")
+		content = reQueryFloatAssign.ReplaceAllString(content, "$1, $2 := fiber.Query[float64]($3, $4), nil")
+		content = reQueryBoolAssign.ReplaceAllString(content, "$1, $2 := fiber.Query[bool]($3, $4), nil")
+
 		content = reParamsInt.ReplaceAllString(content, "fiber.Params[int]($1, ")
 		content = reQueryInt.ReplaceAllString(content, "fiber.Query[int]($1, ")
 		content = reQueryFloat.ReplaceAllString(content, "fiber.Query[float64]($1, ")

--- a/cmd/internal/migrations/v3/generic_helpers_test.go
+++ b/cmd/internal/migrations/v3/generic_helpers_test.go
@@ -21,10 +21,16 @@ func Test_MigrateGenericHelpers(t *testing.T) {
 	file := writeTempFile(t, dir, `package main
 import "github.com/gofiber/fiber/v2"
 func handler(c fiber.Ctx) error {
+    targetedUserID, err := c.ParamsInt("userID")
+    targetedAge, err2 := c.QueryInt("age")
     _ = c.ParamsInt("id", 0)
-    _ = c.QueryInt("age", 0)
+    _ = c.QueryInt("level", 0)
     _ = c.QueryFloat("score", 0.5)
     _ = c.QueryBool("ok", true)
+    _ = targetedUserID
+    _ = targetedAge
+    _ = err
+    _ = err2
     return nil
 }
 `)
@@ -34,8 +40,10 @@ func handler(c fiber.Ctx) error {
 	require.NoError(t, v3.MigrateGenericHelpers(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
+	assert.Contains(t, content, "targetedUserID, err := fiber.Params[int](c, \"userID\"), nil")
+	assert.Contains(t, content, "targetedAge, err2 := fiber.Query[int](c, \"age\"), nil")
 	assert.Contains(t, content, "fiber.Params[int](c, \"id\"")
-	assert.Contains(t, content, "fiber.Query[int](c, \"age\"")
+	assert.Contains(t, content, "fiber.Query[int](c, \"level\"")
 	assert.Contains(t, content, "fiber.Query[float64](c, \"score\"")
 	assert.Contains(t, content, "fiber.Query[bool](c, \"ok\"")
 	assert.Contains(t, buf.String(), "Migrating generic helpers")

--- a/cmd/internal/migrations/v3/middleware_locals.go
+++ b/cmd/internal/migrations/v3/middleware_locals.go
@@ -31,8 +31,8 @@ func MigrateMiddlewareLocals(cmd *cobra.Command, cwd string, _, _ *semver.Versio
 		reTypeAssert := regexp.MustCompile(`([\w\.]+FromContext\([^\)]+\))\.\([^\)]+\)`)
 		content = reTypeAssert.ReplaceAllString(content, "$1")
 
-		reComma := regexp.MustCompile(`(\w+)\s*,\s*\w+\s*:=\s*([\w\.]+FromContext\([^\)]+\))`)
-		content = reComma.ReplaceAllString(content, "$1 := $2")
+		reComma := regexp.MustCompile(`(\w+)\s*,\s*(\w+)\s*:=\s*([\w\.]+FromContext\([^\)]+\))`)
+		content = reComma.ReplaceAllString(content, "$1, $2 := $3, true")
 
 		reCtxKey := regexp.MustCompile(`\s*ContextKey:\s*[^,}\n]+,?`)
 		content = reCtxKey.ReplaceAllString(content, "")

--- a/cmd/internal/migrations/v3/middleware_locals_test.go
+++ b/cmd/internal/migrations/v3/middleware_locals_test.go
@@ -22,11 +22,12 @@ func Test_MigrateMiddlewareLocals(t *testing.T) {
 import "github.com/gofiber/fiber/v2"
 func handler(c fiber.Ctx) error {
     id := c.Locals("requestid").(string)
-    csrfToken, _ := c.Locals("csrf").(string)
+    csrfToken, ok := c.Locals("csrf").(string)
     token := c.Locals("token").(string)
     _ = id
     _ = csrfToken
     _ = token
+    _ = ok
     return nil
 }`)
 
@@ -36,7 +37,7 @@ func handler(c fiber.Ctx) error {
 
 	content := readFile(t, file)
 	assert.Contains(t, content, `id := requestid.FromContext(c)`)
-	assert.Contains(t, content, `csrfToken := csrf.TokenFromContext(c)`)
+	assert.Contains(t, content, `csrfToken, ok := csrf.TokenFromContext(c), true`)
 	assert.Contains(t, content, `token := keyauth.TokenFromContext(c)`)
 	assert.Contains(t, buf.String(), "Migrating middleware locals")
 }


### PR DESCRIPTION
## Summary
- keep second assignment when migrating middleware locals by appending `, true`
- append `, nil` for two-value assignments when replacing Params/Query helpers with generic versions
- update tests for new assignment behaviour

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aa13f966248326ba45cb5fa55a8f43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Migration now handles complex multi-variable assignments for parameter/query extraction, converting them to generic helpers.
  - Supports two-variable locals retrieval patterns, preserving arity by retaining the second variable.
  - Keeps existing simple replacements for direct parameter/query reads.

- Tests
  - Updated test cases to reflect new migration outputs, including generic helper usage, adjusted query parameter expectations, and comma-ok locals handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->