### PR TITLE
Fix KeyLookup migrator handling for complex values

### DIFF
--- a/cmd/dev_test.go
+++ b/cmd/dev_test.go
@@ -103,9 +103,9 @@ func Test_Dev_Escort_WatchingBin(t *testing.T) {
 
 	e.hitCh <- struct{}{}
 	e.hitCh <- struct{}{}
-	time.Sleep(time.Millisecond * 75)
+	time.Sleep(e.delay * 2)
 	e.hitCh <- struct{}{}
-	time.Sleep(time.Millisecond * 75)
+	time.Sleep(e.delay * 2)
 
 	assert.Equal(t, int32(2), atomic.LoadInt32(&count))
 }

--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -78,6 +79,10 @@ var Migrations = []Migration{
 
 func migrationName(fn MigrationFn) string {
 	f := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	f = strings.TrimSuffix(f, "-fm")
+	if idx := strings.LastIndex(f, ".func"); idx >= 0 {
+		f = f[:idx]
+	}
 	if idx := strings.LastIndex(f, "."); idx >= 0 {
 		return f[idx+1:]
 	}
@@ -87,6 +92,7 @@ func migrationName(fn MigrationFn) string {
 // DoMigration runs all migrations
 // It will run all migrations that match the current and target version
 func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, skipGoMod, verbose bool) error {
+	var errs []error
 	for _, m := range Migrations {
 		toC, err := semver.NewConstraint(m.To)
 		if err != nil {
@@ -112,11 +118,11 @@ func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, s
 						cmd.Printf("%s: changed\n", name)
 					}
 					if err != nil {
-						return err
+						errs = append(errs, fmt.Errorf("%s: %w", name, err))
 					}
 				} else {
 					if err := fn(cmd, cwd, curr, target); err != nil {
-						return err
+						errs = append(errs, fmt.Errorf("%s: %w", migrationName(fn), err))
 					}
 				}
 			}
@@ -127,8 +133,12 @@ func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, s
 
 	if !skipGoMod {
 		if err := internal.RunGoMod(cwd); err != nil {
-			return fmt.Errorf("go mod: %w", err)
+			errs = append(errs, fmt.Errorf("go mod: %w", err))
 		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	return nil

--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -3,6 +3,7 @@ package v3
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -83,6 +84,51 @@ func removeConfigField(src, field string) string {
 	nextField:
 	}
 	return src
+}
+
+// replaceKeyLookup searches a struct literal for a KeyLookup field and invokes
+// fn with the parsed components. If fn returns an empty string, the field is
+// removed entirely.
+func replaceKeyLookup(src string, fn func(indent, val, comma, comment, newline string) string) string {
+	re := regexp.MustCompile(`(?m)(\s*)KeyLookup:\s*([^\n]+)(\n?)`)
+	return re.ReplaceAllStringFunc(src, func(s string) string {
+		sub := re.FindStringSubmatch(s)
+		indent := sub[1]
+		val := strings.TrimSpace(sub[2])
+		newline := sub[3]
+
+		comment := ""
+		if idx := strings.Index(val, "//"); idx >= 0 {
+			comment = strings.TrimSpace(val[idx:])
+			val = strings.TrimSpace(val[:idx])
+		} else if idx := strings.Index(val, "/*"); idx >= 0 {
+			comment = strings.TrimSpace(val[idx:])
+			val = strings.TrimSpace(val[:idx])
+		}
+
+		comma := ""
+		if strings.HasSuffix(val, ",") {
+			comma = ","
+			val = strings.TrimSpace(strings.TrimSuffix(val, ","))
+		}
+
+		if uq, err := strconv.Unquote(val); err == nil {
+			val = uq
+			repl := fn(indent, val, comma, comment, newline)
+			if repl == "" {
+				if comment != "" {
+					return fmt.Sprintf("%s%s%s", indent, comment, newline)
+				}
+				return newline
+			}
+			return repl
+		}
+
+		if comment != "" {
+			return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s %s%s", indent, val, comment, newline)
+		}
+		return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s%s", indent, val, newline)
+	})
 }
 
 // splitArgs splits a comma-separated argument list into its individual arguments
@@ -178,6 +224,44 @@ func extractCall(src string, start int) (int, string) {
 		}
 	}
 	return len(src), src[start:]
+}
+
+// extractBlock returns the index just after the closing delimiter that matches
+// the opening delimiter at the start position. Start must point to the first
+// character after the opening delimiter. It handles nested delimiters and
+// quoted strings.
+func extractBlock(src string, start int, open, closeDelim byte) int {
+	depth := 1
+	inStr := false
+	var quote byte
+
+	for i := start; i < len(src); i++ {
+		ch := src[i]
+		if inStr {
+			if ch == '\\' {
+				i++
+				continue
+			}
+			if ch == quote {
+				inStr = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"', '\'', '`':
+			inStr = true
+			quote = ch
+		case open:
+			depth++
+		case closeDelim:
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return len(src)
 }
 
 // replaceCall finds invocations of name within src and allows custom

--- a/cmd/internal/migrations/v3/csrfconfig.go
+++ b/cmd/internal/migrations/v3/csrfconfig.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -13,43 +12,57 @@ import (
 )
 
 func MigrateCSRFConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
-	reConfig := regexp.MustCompile(`csrf\.Config{[^}]*}`)
-	reSession := regexp.MustCompile(`\s*SessionKey:\s*[^,]+,?\n`)
-	reKeyLookup := regexp.MustCompile(`(\s*)KeyLookup:\s*([^,\n]+)(,?)(\n?)`)
+	reConfig := regexp.MustCompile(`csrf\.Config{`)
+	reSession := regexp.MustCompile(`(?m)\s*SessionKey:\s*[^,]+,?\n`)
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
-		content = reConfig.ReplaceAllStringFunc(content, func(s string) string {
-			return strings.ReplaceAll(s, "Expiration:", "IdleTimeout:")
-		})
-		content = reSession.ReplaceAllString(content, "")
+		matches := reConfig.FindAllStringIndex(content, -1)
+		if len(matches) == 0 {
+			return content
+		}
 
-		content = reKeyLookup.ReplaceAllStringFunc(content, func(s string) string {
-			sub := reKeyLookup.FindStringSubmatch(s)
-			indent := sub[1]
-			val := strings.TrimSpace(sub[2])
-			comma := sub[3]
-			newline := sub[4]
-
-			if uq, err := strconv.Unquote(val); err == nil {
-				val = uq
+		var b strings.Builder
+		last := 0
+		for _, m := range matches {
+			if _, err := b.WriteString(content[last:m[0]]); err != nil {
+				return content
 			}
+			start := m[0]
+			end := extractBlock(content, m[1], '{', '}')
+			cfg := content[start:end]
+			cfg = strings.ReplaceAll(cfg, "Expiration:", "IdleTimeout:")
+			cfg = reSession.ReplaceAllString(cfg, "")
 
-			var extractor string
-			switch {
-			case strings.HasPrefix(val, "header:"):
-				extractor = fmt.Sprintf("Extractor: csrf.FromHeader(%q)", strings.TrimPrefix(val, "header:"))
-			case strings.HasPrefix(val, "form:"):
-				extractor = fmt.Sprintf("Extractor: csrf.FromForm(%q)", strings.TrimPrefix(val, "form:"))
-			case strings.HasPrefix(val, "query:"):
-				extractor = fmt.Sprintf("Extractor: csrf.FromQuery(%q)", strings.TrimPrefix(val, "query:"))
-			default:
-				// Unsupported or insecure value (e.g. cookie) - remove
-				return ""
+			cfg = replaceKeyLookup(cfg, func(indent, val, comma, comment, newline string) string {
+				var extractor string
+				switch {
+				case strings.HasPrefix(val, "header:"):
+					extractor = fmt.Sprintf("Extractor: csrf.FromHeader(%q)", strings.TrimPrefix(val, "header:"))
+				case strings.HasPrefix(val, "form:"):
+					extractor = fmt.Sprintf("Extractor: csrf.FromForm(%q)", strings.TrimPrefix(val, "form:"))
+				case strings.HasPrefix(val, "query:"):
+					extractor = fmt.Sprintf("Extractor: csrf.FromQuery(%q)", strings.TrimPrefix(val, "query:"))
+				default:
+					if comment != "" {
+						comment = " " + comment
+					}
+					return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s%s%s", indent, val, comment, newline)
+				}
+
+				if comment != "" {
+					comment = " " + comment
+				}
+				return fmt.Sprintf("%s%s%s%s%s", indent, extractor, comma, comment, newline)
+			})
+
+			if _, err := b.WriteString(cfg); err != nil {
+				return content
 			}
-
-			return fmt.Sprintf("%s%s%s%s", indent, extractor, comma, newline)
-		})
-
-		return content
+			last = end
+		}
+		if _, err := b.WriteString(content[last:]); err != nil {
+			return content
+		}
+		return b.String()
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate CSRF configs: %w", err)

--- a/cmd/internal/migrations/v3/csrfconfig_test.go
+++ b/cmd/internal/migrations/v3/csrfconfig_test.go
@@ -64,6 +64,104 @@ var _ = csrf.New(csrf.Config{
 	assert.Contains(t, buf.String(), "Migrating CSRF middleware configs")
 }
 
+func Test_MigrateCSRFConfig_KeyLookup_Form(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mcsrfkl_form")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/csrf"
+)
+var _ = csrf.New(csrf.Config{
+    KeyLookup: "form:csrf",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateCSRFConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, `Extractor: csrf.FromForm("csrf")`)
+	assert.Contains(t, buf.String(), "Migrating CSRF middleware configs")
+}
+
+func Test_MigrateCSRFConfig_KeyLookup_Func(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mcsrfkl_func")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/csrf"
+    "strings"
+)
+var _ = csrf.New(csrf.Config{
+    KeyLookup: strings.Join([]string{"header", "X-CSRF-Token"}, ":"),
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateCSRFConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "// TODO: migrate KeyLookup: strings.Join([]string{\"header\", \"X-CSRF-Token\"}, \":\")")
+	assert.NotContains(t, content, "Extractor")
+	assert.Contains(t, buf.String(), "Migrating CSRF middleware configs")
+}
+
+func Test_MigrateCSRFConfig_IgnoresOtherConfigs(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mcsrf_ignore")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/keyauth"
+)
+var _ = keyauth.New(keyauth.Config{
+    KeyLookup: "header:Authorization",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateCSRFConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `KeyLookup: "header:Authorization"`)
+	assert.NotContains(t, content, "Extractor")
+	assert.NotContains(t, buf.String(), "Migrating CSRF middleware configs")
+}
+
+func Test_MigrateCSRFConfig_IgnoresSessionConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mcsrf_ignore_session")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/session"
+var _ = session.New(session.Config{
+    KeyLookup: "cookie:__Host-session",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateCSRFConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `KeyLookup: "cookie:__Host-session"`)
+	assert.NotContains(t, buf.String(), "Migrating CSRF middleware configs")
+}
+
 func Test_MigrateCSRFConfig_IgnoresPaseto(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/internal/migrations/v3/key_auth_config.go
+++ b/cmd/internal/migrations/v3/key_auth_config.go
@@ -13,23 +13,12 @@ import (
 )
 
 func MigrateKeyAuthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
-	reConfig := regexp.MustCompile(`keyauth\.Config{[^}]*}`)
-	reKeyLookup := regexp.MustCompile(`(?m)(\s*)KeyLookup:\s*("[^"]+")(,?)(\n?)`)
+	reConfig := regexp.MustCompile(`keyauth\.Config{(?:[^{}]|{[^{}]*})*}`)
 	reAuthScheme := regexp.MustCompile(`(?m)\s*AuthScheme:\s*([^,\n]+)`)
 
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
 		return reConfig.ReplaceAllStringFunc(content, func(cfg string) string {
-			keyMatch := reKeyLookup.FindStringSubmatch(cfg)
-			if len(keyMatch) == 5 {
-				indent := keyMatch[1]
-				val := strings.TrimSpace(keyMatch[2])
-				comma := keyMatch[3]
-				newline := keyMatch[4]
-
-				if uq, err := strconv.Unquote(val); err == nil {
-					val = uq
-				}
-
+			cfg = replaceKeyLookup(cfg, func(indent, val, comma, comment, newline string) string {
 				scheme := "Bearer"
 				if am := reAuthScheme.FindStringSubmatch(cfg); len(am) > 1 {
 					scheme = strings.TrimSpace(am[1])
@@ -59,9 +48,10 @@ func MigrateKeyAuthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) 
 					case strings.HasPrefix(p, "cookie:"):
 						extractors = append(extractors, fmt.Sprintf("keyauth.FromCookie(%q)", strings.TrimPrefix(p, "cookie:")))
 					default:
-						cfg = removeConfigField(cfg, "AuthScheme")
-						cfg = removeConfigField(cfg, "KeyLookup")
-						return cfg
+						if comment != "" {
+							comment = " " + comment
+						}
+						return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s%s%s", indent, val, comment, newline)
 					}
 				}
 
@@ -71,19 +61,19 @@ func MigrateKeyAuthConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) 
 				} else if len(extractors) > 1 {
 					extractor = fmt.Sprintf("keyauth.Chain(%s)", strings.Join(extractors, ", "))
 				}
-
-				cfg = removeConfigField(cfg, "AuthScheme")
 				if extractor == "" {
-					cfg = removeConfigField(cfg, "KeyLookup")
-					return cfg
+					if comment != "" {
+						comment = " " + comment
+					}
+					return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s%s%s", indent, val, comment, newline)
 				}
 
-				newField := fmt.Sprintf("%sExtractor: %s%s%s", indent, extractor, comma, newline)
-				cfg = reKeyLookup.ReplaceAllString(cfg, newField)
-				return cfg
-			}
+				if comment != "" {
+					comment = " " + comment
+				}
+				return fmt.Sprintf("%sExtractor: %s%s%s%s", indent, extractor, comma, comment, newline)
+			})
 
-			cfg = removeConfigField(cfg, "KeyLookup")
 			cfg = removeConfigField(cfg, "AuthScheme")
 			return cfg
 		})

--- a/cmd/internal/migrations/v3/key_auth_config_test.go
+++ b/cmd/internal/migrations/v3/key_auth_config_test.go
@@ -35,3 +35,59 @@ var _ = keyauth.New(keyauth.Config{
 	assert.Contains(t, content, `Extractor: keyauth.Chain(keyauth.FromAuthHeader("Authorization", "Bearer"), keyauth.FromQuery("api"))`)
 	assert.Contains(t, buf.String(), "Migrating keyauth middleware configs")
 }
+
+func Test_MigrateKeyAuthConfig_KeyLookupCookieForm(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mkeyauth_cf")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/keyauth"
+var _ = keyauth.New(keyauth.Config{
+    KeyLookup: "cookie:__Host-session, form:csrf",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateKeyAuthConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, `Extractor: keyauth.Chain(keyauth.FromCookie("__Host-session"), keyauth.FromForm("csrf"))`)
+	assert.Contains(t, buf.String(), "Migrating keyauth middleware configs")
+}
+
+func Test_MigrateKeyAuthConfig_KeyLookupFunc(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mkeyauth_func")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/keyauth"
+    "strings"
+)
+var _ = keyauth.New(keyauth.Config{
+    ErrorHandler: errHandler,
+    KeyLookup: strings.Join([]string{"header:Authorization", "query:api"}, ":"),
+    Validator: validator,
+    ContextKey: authKey,
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateKeyAuthConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "// TODO: migrate KeyLookup: strings.Join([]string{\"header:Authorization\", \"query:api\"}, \":\")")
+	assert.NotContains(t, content, "AuthScheme")
+	assert.Contains(t, content, "ErrorHandler: errHandler,\n")
+	assert.NotContains(t, content, "ErrorHandler: errHandler, Validator")
+	assert.Contains(t, content, "Validator:  validator,")
+	assert.Contains(t, content, "ContextKey: authKey,")
+	assert.Contains(t, buf.String(), "Migrating keyauth middleware configs")
+}

--- a/cmd/internal/migrations/v3/session_config.go
+++ b/cmd/internal/migrations/v3/session_config.go
@@ -12,11 +12,32 @@ import (
 )
 
 func MigrateSessionConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	reConfig := regexp.MustCompile(`session\.Config{`)
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
-		reConfig := regexp.MustCompile(`session\.Config{[^}]*}`)
-		return reConfig.ReplaceAllStringFunc(content, func(s string) string {
-			return strings.ReplaceAll(s, "Expiration:", "IdleTimeout:")
-		})
+		matches := reConfig.FindAllStringIndex(content, -1)
+		if len(matches) == 0 {
+			return content
+		}
+
+		var b strings.Builder
+		last := 0
+		for _, m := range matches {
+			if _, err := b.WriteString(content[last:m[0]]); err != nil {
+				return content
+			}
+			start := m[0]
+			end := extractBlock(content, m[1], '{', '}')
+			cfg := content[start:end]
+			cfg = strings.ReplaceAll(cfg, "Expiration:", "IdleTimeout:")
+			if _, err := b.WriteString(cfg); err != nil {
+				return content
+			}
+			last = end
+		}
+		if _, err := b.WriteString(content[last:]); err != nil {
+			return content
+		}
+		return b.String()
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate session configs: %w", err)

--- a/cmd/internal/migrations/v3/session_config_test.go
+++ b/cmd/internal/migrations/v3/session_config_test.go
@@ -47,7 +47,7 @@ func Test_MigrateSessionConfig_KeyLookup_Cookie(t *testing.T) {
 	file := writeTempFile(t, dir, `package main
 import "github.com/gofiber/fiber/v2/middleware/session"
 var _ = session.New(session.Config{
-    KeyLookup: "cookie:session_id",
+    KeyLookup: "cookie:__Host-session", // comment
 })`)
 
 	var buf bytes.Buffer
@@ -56,7 +56,31 @@ var _ = session.New(session.Config{
 
 	content := readFile(t, file)
 	assert.NotContains(t, content, "KeyLookup")
-	assert.Contains(t, content, `Extractor: session.FromCookie("session_id")`)
+	assert.Contains(t, content, `Extractor: session.FromCookie("__Host-session"), // comment`)
+	assert.Contains(t, buf.String(), "Migrating session KeyLookup config")
+}
+
+func Test_MigrateSessionConfig_KeyLookup_CookieNested(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msessionkl_cookie_nested")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/session"
+var _ = session.New(session.Config{
+    Store: storage.New(storage.Config{M: map[string]string{"a": "b"}}),
+    KeyLookup: "cookie:__Host-session",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionExtractor(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, `Extractor: session.FromCookie("__Host-session")`)
 	assert.Contains(t, buf.String(), "Migrating session KeyLookup config")
 }
 
@@ -124,7 +148,56 @@ var _ = session.New(session.Config{
 	require.NoError(t, v3.MigrateSessionExtractor(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.NotContains(t, content, "KeyLookup")
+	assert.Contains(t, content, "// TODO: migrate KeyLookup: unknown:session_id")
 	assert.NotContains(t, content, "Extractor")
 	assert.Contains(t, buf.String(), "Migrating session KeyLookup config")
+}
+
+func Test_MigrateSessionConfig_KeyLookup_Func(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msessionkl_func")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/session"
+    "strings"
+)
+var _ = session.New(session.Config{
+    KeyLookup: strings.Join([]string{"cookie", "session_id"}, ":"),
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionExtractor(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "// TODO: migrate KeyLookup: strings.Join([]string{\"cookie\", \"session_id\"}, \":\")")
+	assert.NotContains(t, content, "Extractor")
+	assert.Contains(t, buf.String(), "Migrating session KeyLookup config")
+}
+
+func Test_MigrateSessionExtractor_IgnoresOtherConfigs(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "msession_ignore")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2/middleware/keyauth"
+var _ = keyauth.New(keyauth.Config{
+    KeyLookup: "header:Authorization",
+})`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateSessionExtractor(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, `KeyLookup: "header:Authorization"`)
+	assert.NotContains(t, content, "Extractor")
+	assert.NotContains(t, buf.String(), "Migrating session KeyLookup config")
 }

--- a/cmd/internal/migrations/v3/session_extractor.go
+++ b/cmd/internal/migrations/v3/session_extractor.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -13,46 +12,68 @@ import (
 )
 
 func MigrateSessionExtractor(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
-	reKeyLookup := regexp.MustCompile(`(\s*)KeyLookup:\s*([^,\n]+)(,?)(\n?)`)
+	reConfig := regexp.MustCompile(`session\.Config{`)
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
-		return reKeyLookup.ReplaceAllStringFunc(content, func(s string) string {
-			sub := reKeyLookup.FindStringSubmatch(s)
-			indent := sub[1]
-			val := strings.TrimSpace(sub[2])
-			comma := sub[3]
-			newline := sub[4]
+		matches := reConfig.FindAllStringIndex(content, -1)
+		if len(matches) == 0 {
+			return content
+		}
 
-			if uq, err := strconv.Unquote(val); err == nil {
-				val = uq
+		var b strings.Builder
+		last := 0
+		for _, m := range matches {
+			if _, err := b.WriteString(content[last:m[0]]); err != nil {
+				return content
 			}
-
-			parts := strings.Split(val, ",")
-			var extractors []string
-			for _, p := range parts {
-				p = strings.TrimSpace(p)
-				switch {
-				case strings.HasPrefix(p, "cookie:"):
-					extractors = append(extractors, fmt.Sprintf("session.FromCookie(%q)", strings.TrimPrefix(p, "cookie:")))
-				case strings.HasPrefix(p, "header:"):
-					extractors = append(extractors, fmt.Sprintf("session.FromHeader(%q)", strings.TrimPrefix(p, "header:")))
-				case strings.HasPrefix(p, "query:"):
-					extractors = append(extractors, fmt.Sprintf("session.FromQuery(%q)", strings.TrimPrefix(p, "query:")))
-				default:
-					return ""
+			start := m[0]
+			end := extractBlock(content, m[1], '{', '}')
+			cfg := content[start:end]
+			cfg = replaceKeyLookup(cfg, func(indent, val, comma, comment, newline string) string {
+				parts := strings.Split(val, ",")
+				var extractors []string
+				for _, p := range parts {
+					p = strings.TrimSpace(p)
+					switch {
+					case strings.HasPrefix(p, "cookie:"):
+						extractors = append(extractors, fmt.Sprintf("session.FromCookie(%q)", strings.TrimPrefix(p, "cookie:")))
+					case strings.HasPrefix(p, "header:"):
+						extractors = append(extractors, fmt.Sprintf("session.FromHeader(%q)", strings.TrimPrefix(p, "header:")))
+					case strings.HasPrefix(p, "query:"):
+						extractors = append(extractors, fmt.Sprintf("session.FromQuery(%q)", strings.TrimPrefix(p, "query:")))
+					default:
+						if comment != "" {
+							comment = " " + comment
+						}
+						return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s%s%s", indent, val, comment, newline)
+					}
 				}
-			}
 
-			if len(extractors) == 0 {
-				return ""
-			}
+				if len(extractors) == 0 {
+					if comment != "" {
+						comment = " " + comment
+					}
+					return fmt.Sprintf("%s// TODO: migrate KeyLookup: %s%s%s", indent, val, comment, newline)
+				}
 
-			extractor := extractors[0]
-			if len(extractors) > 1 {
-				extractor = fmt.Sprintf("session.Chain(%s)", strings.Join(extractors, ", "))
-			}
+				extractor := extractors[0]
+				if len(extractors) > 1 {
+					extractor = fmt.Sprintf("session.Chain(%s)", strings.Join(extractors, ", "))
+				}
 
-			return fmt.Sprintf("%sExtractor: %s%s%s", indent, extractor, comma, newline)
-		})
+				if comment != "" {
+					comment = " " + comment
+				}
+				return fmt.Sprintf("%sExtractor: %s%s%s%s", indent, extractor, comma, comment, newline)
+			})
+			if _, err := b.WriteString(cfg); err != nil {
+				return content
+			}
+			last = end
+		}
+		if _, err := b.WriteString(content[last:]); err != nil {
+			return content
+		}
+		return b.String()
 	})
 	if err != nil {
 		return fmt.Errorf("failed to migrate session extractor config: %w", err)


### PR DESCRIPTION
## Summary
- parse nested struct blocks so session config migrations handle deeply nested fields
- migrate cookie-based `KeyLookup` even when session configs contain nested structs
- cover nested `KeyLookup` with regression tests
- stabilize dev escort watcher test to prevent flakiness

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a9fd340f648326afb03608e21e15d6