### PR TITLE
preserve config formatting in migrations

### DIFF
--- a/cmd/internal/migrations/v3/config_listener_fields.go
+++ b/cmd/internal/migrations/v3/config_listener_fields.go
@@ -52,11 +52,16 @@ func MigrateConfigListenerFields(cmd *cobra.Command, cwd string, _, _ *semver.Ve
 			inner = regexp.MustCompile(`,\s*,`).ReplaceAllString(inner, ",")
 			inner = strings.TrimSpace(inner)
 			inner = strings.TrimPrefix(inner, ",")
-			inner = strings.TrimSuffix(inner, ",")
 			inner = strings.TrimSpace(inner)
 			if inner == "" {
 				return "fiber.Config{}"
 			}
+			if strings.Contains(inner, "\n") {
+				inner = strings.TrimSuffix(inner, ",")
+				inner = strings.TrimSpace(inner)
+				return "fiber.Config{\n" + inner + ",\n}"
+			}
+			inner = strings.TrimSuffix(inner, ",")
 			return "fiber.Config{" + inner + "}"
 		})
 	})

--- a/cmd/internal/migrations/v3/config_listener_fields_test.go
+++ b/cmd/internal/migrations/v3/config_listener_fields_test.go
@@ -56,6 +56,33 @@ func main() {
 	assert.Contains(t, buf.String(), "Migrating listener related config fields")
 }
 
+func Test_MigrateConfigListenerFields_PreserveFormatting(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mconf_format")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2"
+func newApp() *fiber.App {
+    var engine any
+    return fiber.New(fiber.Config{
+        Views:       engine,
+        ViewsLayout: "layouts/main",
+        Prefork:     true,
+    })
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateConfigListenerFields(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "\tViews:       engine,\n\t\tViewsLayout: \"layouts/main\",\n\t})")
+	assert.Contains(t, buf.String(), "Migrating listener related config fields")
+}
+
 func Test_MigrateConfigListenerFields_ExistingListenConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep multi-line fiber.Config literals formatted when removing deprecated listener fields
- add regression test ensuring formatting is preserved

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68aa18f97394832692ca3361643387b3