### PR TITLE
refactor: stabilize dev escort tests

### DIFF
--- a/cmd/dev_test.go
+++ b/cmd/dev_test.go
@@ -56,7 +56,6 @@ func Test_Dev_Escort_Run(t *testing.T) {
 	e.sig = make(chan os.Signal, 1)
 
 	go func() {
-		time.Sleep(time.Millisecond * 500)
 		e.sig <- syscall.SIGINT
 	}()
 
@@ -103,11 +102,13 @@ func Test_Dev_Escort_WatchingBin(t *testing.T) {
 
 	e.hitCh <- struct{}{}
 	e.hitCh <- struct{}{}
-	time.Sleep(e.delay * 2)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&count) == 1
+	}, time.Second, e.delay)
 	e.hitCh <- struct{}{}
-	time.Sleep(e.delay * 2)
-
-	assert.Equal(t, int32(2), atomic.LoadInt32(&count))
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&count) == 2
+	}, time.Second, e.delay)
 }
 
 func Test_Dev_Escort_WatchingFiles(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace fixed sleeps with deterministic synchronization in dev escort tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1f9d8a688326bc0420b42f0a89df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability and speed of development workflow tests by replacing fixed delays with event-driven assertions and timeouts. This reduces flakiness, shortens test execution, and provides more deterministic outcomes.
  * Eliminated unnecessary waits before interrupt handling, streamlining test flow.
  * Overall impact: more stable CI runs, faster feedback cycles, and increased confidence in test results without altering any user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->