### PR TITLE
feat: migrate logger generics

### DIFF
--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -43,6 +43,7 @@ var Migrations = []Migration{
 			v3migrations.MigrateAddMethod,
 			v3migrations.MigrateMimeConstants,
 			v3migrations.MigrateLoggerTags,
+			v3migrations.MigrateLoggerGenerics,
 			v3migrations.MigrateStaticRoutes,
 			v3migrations.MigrateTrustedProxyConfig,
 			v3migrations.MigrateMount,

--- a/cmd/internal/migrations/v3/logger_generics.go
+++ b/cmd/internal/migrations/v3/logger_generics.go
@@ -1,0 +1,37 @@
+package v3
+
+import (
+	"fmt"
+	"regexp"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+
+	"github.com/gofiber/cli/cmd/internal"
+)
+
+func MigrateLoggerGenerics(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
+	reAllLogger := regexp.MustCompile(`(\w+)\.AllLogger([^\w\[]|$)`)
+	reConfigurableLogger := regexp.MustCompile(`(\w+)\.ConfigurableLogger([^\w\[]|$)`)
+	reDefaultLogger := regexp.MustCompile(`(\w+)\.DefaultLogger\(\)`)
+	reSetLogger := regexp.MustCompile(`(\w+)\.SetLogger\(`)
+	reLoggerToWriter := regexp.MustCompile(`(\w+)\.LoggerToWriter\(`)
+
+	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
+		content = reAllLogger.ReplaceAllString(content, `$1.AllLogger[any]$2`)
+		content = reConfigurableLogger.ReplaceAllString(content, `$1.ConfigurableLogger[any]$2`)
+		content = reDefaultLogger.ReplaceAllString(content, `$1.DefaultLogger[any]()`)
+		content = reSetLogger.ReplaceAllString(content, `$1.SetLogger[any](`)
+		content = reLoggerToWriter.ReplaceAllString(content, `$1.LoggerToWriter[any](`)
+		return content
+	})
+	if err != nil {
+		return fmt.Errorf("failed to migrate logger generics: %w", err)
+	}
+	if !changed {
+		return nil
+	}
+
+	cmd.Println("Migrating logger generics")
+	return nil
+}

--- a/cmd/internal/migrations/v3/logger_generics_test.go
+++ b/cmd/internal/migrations/v3/logger_generics_test.go
@@ -1,0 +1,47 @@
+package v3_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gofiber/cli/cmd/internal/migrations/v3"
+)
+
+func Test_MigrateLoggerGenerics(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mloggenericstest")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import (
+    fiberlog "github.com/gofiber/fiber/v2/log"
+)
+var _ fiberlog.AllLogger = (*customLogger)(nil)
+var _ fiberlog.ConfigurableLogger = (*customLogger)(nil)
+func main() {
+    logger := fiberlog.DefaultLogger()
+    fiberlog.SetLogger(logger)
+    _ = fiberlog.LoggerToWriter(logger, fiberlog.LevelInfo)
+}
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateLoggerGenerics(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "AllLogger =")
+	assert.NotContains(t, content, "ConfigurableLogger =")
+	assert.Contains(t, content, "AllLogger[any]")
+	assert.Contains(t, content, "ConfigurableLogger[any]")
+	assert.Contains(t, content, "DefaultLogger[any]()")
+	assert.Contains(t, content, "SetLogger[any](")
+	assert.Contains(t, content, "LoggerToWriter[any](")
+	assert.Contains(t, buf.String(), "Migrating logger generics")
+}


### PR DESCRIPTION
## Summary
- add migration to update logger interfaces and functions for generics
- register migration and cover with tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf8dd7e6c8326b772dab0107af213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The migration tool now automatically updates projects to use generic logger APIs during supported version upgrades (2.x to <4.0). It converts existing logger types and functions to their generic equivalents and provides clear progress output during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->