### PR TITLE
Honor force option when migrating with hash

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -265,6 +265,7 @@ issues:
       linters:
         - bodyclose
         - err113
+        - revive
     - source: 'fmt.Fprintf?'
       linters:
         - errcheck

--- a/cmd/internal/migrations/common.go
+++ b/cmd/internal/migrations/common.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	pkgRegex         = regexp.MustCompile(`(?m)^(\s*require\s+)?(github\.com/gofiber/fiber/)(v\d+)(\s+)(v[\w.-]+)$`)
+	pkgRegex         = regexp.MustCompile(`(?m)^(\s*(?:require\s+)?)(github\.com/gofiber/fiber/)(v\d+)(\s+)(v[\w.-]+)$`)
 	fiberImportRegex = regexp.MustCompile(`(^|")github\.com/gofiber/fiber/v\d+`)
 )
 

--- a/cmd/internal/migrations/common_test.go
+++ b/cmd/internal/migrations/common_test.go
@@ -20,8 +20,8 @@ func Test_MigrateGoPkgs(t *testing.T) {
 
 	mainContent := `package main
 import (
-    fiber "github.com/gofiber/fiber/v2"
-    "github.com/gofiber/fiber/v2/middleware/adaptor"
+    fiber "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/middleware/adaptor"
 )
 func main() {
     _, _ = fiber.New(), adaptor.New()

--- a/cmd/internal/migrations/exec_stub_test.go
+++ b/cmd/internal/migrations/exec_stub_test.go
@@ -36,5 +36,5 @@ func TestHelperProcess(t *testing.T) {
 	if out := os.Getenv("GO_HELPER_STDOUT"); out != "" {
 		_, _ = fmt.Fprint(os.Stdout, out)
 	}
-	os.Exit(0) //nolint:revive // helper process exits intentionally
+	os.Exit(0) // helper process exits intentionally
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -94,8 +94,9 @@ func migrateRunE(cmd *cobra.Command, opts MigrateOptions) error {
 		}
 	}
 
-	if !targetVersion.GreaterThan(currentVersion) && !opts.Force {
-		return fmt.Errorf("target version v%s is not greater than current version v%s", opts.TargetVersionS, currentVersionS)
+	if !opts.Force && !targetVersion.GreaterThan(currentVersion) {
+		cmd.Printf("Fiber already at %s\n", currentVersionS)
+		return nil
 	}
 
 	wd, err := os.Getwd()

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -65,6 +65,8 @@ go 1.20
 require github.com/gofiber/fiber/v2 v2.0.6
 `
 
+const hashABC = "abcdef1234567890abcdef1234567890abcdef12"
+
 func Test_Migrate_V2_to_V3(t *testing.T) {
 	dir, err := os.MkdirTemp("", "migrate_v2_v3")
 	require.NoError(t, err)
@@ -251,9 +253,11 @@ require github.com/gofiber/fiber/v3 v3.0.0
 
 	t.Run("without force", func(t *testing.T) {
 		cmd := newMigrateCmd()
+		setupCmd()
+		defer teardownCmd()
 		out, err := runCobraCmd(cmd, "-t=3.0.0")
-		require.Error(t, err)
-		assert.Contains(t, out, "not greater")
+		require.NoError(t, err)
+		assert.Contains(t, out, "Fiber already at 3.0.0")
 	})
 
 	t.Run("force", func(t *testing.T) {
@@ -355,7 +359,7 @@ func Test_Migrate_WithHash(t *testing.T) {
 	require.NoError(t, os.Chdir(dir))
 	defer func() { require.NoError(t, os.Chdir(cwd)) }()
 
-	hash := "abcdef1234567890abcdef1234567890abcdef12"
+	hash := hashABC
 	short := hash[:7]
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -422,7 +426,7 @@ func Test_Migrate_WithHash_DowngradeWithForce(t *testing.T) {
 	require.NoError(t, os.Chdir(dir))
 	defer func() { require.NoError(t, os.Chdir(cwd)) }()
 
-	hash := "abcdef1234567890abcdef1234567890abcdef12"
+	hash := hashABC
 	short := hash[:7]
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -434,8 +438,10 @@ func Test_Migrate_WithHash_DowngradeWithForce(t *testing.T) {
 		setupCmd()
 		defer teardownCmd()
 		out, err := runCobraCmd(cmd, "-t=3.0.0", "--hash="+short)
-		require.Error(t, err)
-		assert.Contains(t, out, "not greater")
+		require.NoError(t, err)
+		assert.Contains(t, out, "Fiber already at")
+		gm := readFileTB(t, filepath.Join(dir, "go.mod"))
+		assert.Contains(t, gm, "fedcba654321")
 	})
 
 	t.Run("force", func(t *testing.T) {
@@ -449,4 +455,79 @@ func Test_Migrate_WithHash_DowngradeWithForce(t *testing.T) {
 		assert.Contains(t, gm, "v3.0.1-0.20200102030405-abcdef123456")
 		assert.NotContains(t, gm, "fedcba654321")
 	})
+}
+
+func Test_Migrate_Force_ResetVersion(t *testing.T) {
+	dir, err := os.MkdirTemp("", "migrate_hash_reset")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	goMod := "module example\n\n" +
+		"go 1.20\n\n" +
+		"require github.com/gofiber/fiber/v3\tv3.0.1-0.20200102030405-abcdef123456\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o600))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer func() { require.NoError(t, os.Chdir(cwd)) }()
+
+	t.Run("without force", func(t *testing.T) {
+		cmd := newMigrateCmd()
+		setupCmd()
+		defer teardownCmd()
+		out, err := runCobraCmd(cmd, "-t=3.0.0")
+		require.NoError(t, err)
+		assert.Contains(t, out, "Fiber already at")
+		gm := readFileTB(t, filepath.Join(dir, "go.mod"))
+		assert.Contains(t, gm, "abcdef123456")
+	})
+
+	t.Run("force", func(t *testing.T) {
+		cmd := newMigrateCmd()
+		setupCmd()
+		defer teardownCmd()
+		_, err := runCobraCmd(cmd, "-t=3.0.0", "-f")
+		require.NoError(t, err)
+
+		gm := readFileTB(t, filepath.Join(dir, "go.mod"))
+		assert.Contains(t, gm, "github.com/gofiber/fiber/v3\tv3.0.0")
+		assert.NotContains(t, gm, "abcdef123456")
+	})
+}
+
+func Test_Migrate_WithHash_RequireBlock(t *testing.T) {
+	dir, err := os.MkdirTemp("", "migrate_hash_block")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	goMod := "module example\n\n" +
+		"go 1.20\n\n" +
+		"require (\n" +
+		"\tgithub.com/gofiber/fiber/v3 v3.0.0-beta.5\n" +
+		")\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o600))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer func() { require.NoError(t, os.Chdir(cwd)) }()
+
+	hash := hashABC
+	short := hash[:7]
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	commitURL := "https://api.github.com/repos/gofiber/fiber/commits/" + short
+	httpmock.RegisterResponder(http.MethodGet, commitURL, httpmock.NewBytesResponder(200, []byte(`{"sha":"`+hash+`","commit":{"committer":{"date":"2020-01-02T03:04:05Z"}}}`)))
+
+	cmd := newMigrateCmd()
+	setupCmd()
+	defer teardownCmd()
+	_, err = runCobraCmd(cmd, "-t=3.0.0-beta.5", "--hash="+short, "-f")
+	require.NoError(t, err)
+
+	gm := readFileTB(t, filepath.Join(dir, "go.mod"))
+	assert.Contains(t, gm, "github.com/gofiber/fiber/v3 v3.0.0-beta.5.0.20200102030405-abcdef123456")
 }


### PR DESCRIPTION
## Summary
- fix go.mod Fiber version replacement when using require blocks
- ensure `--force` uses provided hash or version and keeps newer version when not forced
- add tests covering force and hash downgrade scenarios

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0983d58483268b6f36178d84b57c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved migration handling of go.mod entries, including require blocks and pseudo-versions.
  - Better support for migrations using commit hashes, resolving to appropriate versions.

- Bug Fixes
  - Migrating to the same or an older version now performs a no-op with a clear message instead of failing.

- Tests
  - Expanded coverage for v2→v3 migrations, force behavior, commit-hash flows, and require-block scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->