### PR TITLE
cache GitHub GET responses

### DIFF
--- a/cmd/httpcache.go
+++ b/cmd/httpcache.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+)
+
+var (
+	cacheMu       sync.RWMutex
+	responseCache = make(map[string][]byte)
+)
+
+// cachedGET performs an HTTP GET request and caches successful responses.
+// Headers may be nil. Only responses with status 200 are cached.
+func cachedGET(ctx context.Context, url string, headers map[string]string) (body []byte, status int, err error) {
+	cacheMu.RLock()
+	if b, ok := responseCache[url]; ok {
+		cacheMu.RUnlock()
+		return b, http.StatusOK, nil
+	}
+	cacheMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("do request: %w", err)
+	}
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	body, err = io.ReadAll(res.Body)
+	if err != nil {
+		return nil, res.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+
+	if res.StatusCode == http.StatusOK {
+		cacheMu.Lock()
+		responseCache[url] = body
+		cacheMu.Unlock()
+	}
+
+	return body, res.StatusCode, nil
+}
+
+// clearHTTPCache removes all cached responses. It is intended for testing.
+func clearHTTPCache() {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	responseCache = make(map[string][]byte)
+}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -134,26 +133,15 @@ func pseudoVersionFromHash(base *semver.Version, hash string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", fmt.Errorf("create http request: %w", err)
-	}
-	req.Header.Set("User-Agent", "fiber-cli")
-
-	client := http.Client{}
-	res, err := client.Do(req)
+	headers := map[string]string{"User-Agent": "fiber-cli"}
+	b, status, err := cachedGET(ctx, url, headers)
 	if err != nil {
 		return "", fmt.Errorf("http request failed: %w", err)
 	}
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
-		}
-	}()
-	if res.StatusCode != http.StatusOK {
-		msg, err := io.ReadAll(res.Body)
-		if err != nil || len(msg) == 0 {
-			msg = []byte(res.Status)
+	if status != http.StatusOK {
+		msg := b
+		if len(msg) == 0 {
+			msg = []byte(http.StatusText(status))
 		}
 		return "", fmt.Errorf("http request failed: %s", strings.TrimSpace(string(msg)))
 	}
@@ -169,7 +157,7 @@ func pseudoVersionFromHash(base *semver.Version, hash string) (string, error) {
 		} `json:"commit"`
 		SHA string `json:"sha"`
 	}
-	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return "", fmt.Errorf("decode response: %w", err)
 	}
 

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -183,6 +183,7 @@ func main() {
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/gofiber/fiber/releases/latest", httpmock.NewBytesResponder(200, []byte(`{"name":"v3.0.0"}`)))
 
 	cmd := newMigrateCmd()
@@ -363,6 +364,7 @@ func Test_Migrate_WithHash(t *testing.T) {
 	short := hash[:7]
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 	commitURL := "https://api.github.com/repos/gofiber/fiber/commits/" + short
 	httpmock.RegisterResponder(http.MethodGet, commitURL, httpmock.NewBytesResponder(200, []byte(`{"sha":"`+hash+`","commit":{"committer":{"date":"2020-01-02T03:04:05Z"}}}`)))
 
@@ -396,6 +398,7 @@ func Test_Migrate_WithHash_UpdatePseudoVersion(t *testing.T) {
 	short := hash[:7]
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 	commitURL := "https://api.github.com/repos/gofiber/fiber/commits/" + short
 	httpmock.RegisterResponder(http.MethodGet, commitURL, httpmock.NewBytesResponder(200, []byte(`{"sha":"`+hash+`","commit":{"committer":{"date":"2020-01-03T03:04:05Z"}}}`)))
 
@@ -430,6 +433,7 @@ func Test_Migrate_WithHash_DowngradeWithForce(t *testing.T) {
 	short := hash[:7]
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 	commitURL := "https://api.github.com/repos/gofiber/fiber/commits/" + short
 	httpmock.RegisterResponder(http.MethodGet, commitURL, httpmock.NewBytesResponder(200, []byte(`{"sha":"`+hash+`","commit":{"committer":{"date":"2020-01-02T03:04:05Z"}}}`)))
 
@@ -519,6 +523,7 @@ func Test_Migrate_WithHash_RequireBlock(t *testing.T) {
 	short := hash[:7]
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 	commitURL := "https://api.github.com/repos/gofiber/fiber/commits/" + short
 	httpmock.RegisterResponder(http.MethodGet, commitURL, httpmock.NewBytesResponder(200, []byte(`{"sha":"`+hash+`","commit":{"committer":{"date":"2020-01-02T03:04:05Z"}}}`)))
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -82,6 +82,7 @@ func Test_Root_CheckCliVersion(t *testing.T) {
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 
 	httpmock.RegisterResponder(http.MethodGet, latestCliVersionURL, httpmock.NewErrorResponder(errors.New("network error")))
 

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -20,6 +20,7 @@ func Test_Upgrade_upgradeRunE(t *testing.T) {
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
 
 	httpmock.RegisterResponder(http.MethodGet, latestCliVersionURL, httpmock.NewErrorResponder(errors.New("network error")))
 
@@ -34,6 +35,7 @@ func Test_Upgrade_upgradeRunE(t *testing.T) {
 
 	at.Contains(b.String(), "99.99.99")
 
+	clearHTTPCache()
 	httpmock.RegisterResponder(http.MethodGet, latestCliVersionURL, httpmock.NewBytesResponder(200, fakeCliVersionResponse(version)))
 
 	b.Reset()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -74,34 +74,19 @@ func LatestCliVersion() (string, error) {
 }
 
 func latestVersionByURL(url string) (string, error) {
-	var (
-		res *http.Response
-		b   []byte
-	)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", fmt.Errorf("create http request: %w", err)
-	}
-
-	client := &http.Client{}
-	res, err = client.Do(req)
+	b, status, err := cachedGET(ctx, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("http request failed: %w", err)
 	}
-
-	defer func() {
-		if cerr := res.Body.Close(); cerr != nil && err == nil {
-			err = cerr
+	if status != http.StatusOK {
+		msg := strings.TrimSpace(string(b))
+		if msg == "" {
+			msg = http.StatusText(status)
 		}
-	}()
-
-	b, err = io.ReadAll(res.Body)
-	if err != nil {
-		return "", fmt.Errorf("read response body: %w", err)
+		return "", fmt.Errorf("http request failed: %s", msg)
 	}
 
 	if submatch := latestVersionRegexp.FindSubmatch(b); len(submatch) == 2 {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -16,6 +16,7 @@ func Test_Version_Printer(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
+		clearHTTPCache()
 
 		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, fakeVersionResponse))
 
@@ -27,6 +28,7 @@ func Test_Version_Printer(t *testing.T) {
 	t.Run("latest err", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
+		clearHTTPCache()
 
 		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, []byte("no version")))
 
@@ -115,6 +117,7 @@ func Test_Version_Latest(t *testing.T) {
 	t.Run("http get error", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
+		clearHTTPCache()
 
 		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewErrorResponder(errors.New("network error")))
 
@@ -125,6 +128,7 @@ func Test_Version_Latest(t *testing.T) {
 	t.Run("version matched", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
+		clearHTTPCache()
 
 		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, fakeVersionResponse))
 
@@ -136,6 +140,7 @@ func Test_Version_Latest(t *testing.T) {
 	t.Run("no version matched", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
+		clearHTTPCache()
 
 		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, []byte("no version")))
 
@@ -147,3 +152,20 @@ func Test_Version_Latest(t *testing.T) {
 var latestVersionURL = "https://api.github.com/repos/gofiber/fiber/releases/latest"
 
 var fakeVersionResponse = []byte(`{ "url": "https://api.github.com/repos/gofiber/fiber/releases/32189569", "assets_url": "https://api.github.com/repos/gofiber/fiber/releases/32189569/assets", "upload_url": "https://uploads.github.com/repos/gofiber/fiber/releases/32189569/assets{?name,label}", "html_url": "https://github.com/gofiber/fiber/releases/tag/v2.0.6", "id": 32189569, "node_id": "MDc6UmVsZWFzZTMyMTg5NTY5", "tag_name": "v2.0.6", "target_commitish": "master", "name": "v2.0.6", "draft": false, "author": { "login": "Fenny", "id": 25108519, "node_id": "MDQ6VXNlcjI1MTA4NTE5", "avatar_url": "https://avatars1.githubusercontent.com/u/25108519?v=4", "gravatar_id": "", "url": "https://api.github.com/users/Fenny", "html_url": "https://github.com/Fenny", "followers_url": "https://api.github.com/users/Fenny/followers", "following_url": "https://api.github.com/users/Fenny/following{/other_user}", "gists_url": "https://api.github.com/users/Fenny/gists{/gist_id}", "starred_url": "https://api.github.com/users/Fenny/starred{/owner}{/repo}", "subscriptions_url": "https://api.github.com/users/Fenny/subscriptions", "organizations_url": "https://api.github.com/users/Fenny/orgs", "repos_url": "https://api.github.com/users/Fenny/repos", "events_url": "https://api.github.com/users/Fenny/events{/privacy}", "received_events_url": "https://api.github.com/users/Fenny/received_events", "type": "User", "site_admin": false }, "prerelease": false, "created_at": "2020-10-05T19:54:02Z", "published_at": "2020-10-05T22:10:27Z", "assets": [], "tarball_url": "https://api.github.com/repos/gofiber/fiber/tarball/v2.0.6", "zipball_url": "https://api.github.com/repos/gofiber/fiber/zipball/v2.0.6" }`)
+
+func Test_LatestVersion_Cache(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	clearHTTPCache()
+
+	httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, fakeVersionResponse))
+
+	_, err := LatestFiberVersion()
+	require.NoError(t, err)
+
+	_, err = LatestFiberVersion()
+	require.NoError(t, err)
+
+	info := httpmock.GetCallCountInfo()
+	require.Equal(t, 1, info["GET "+latestVersionURL])
+}


### PR DESCRIPTION
## Summary
- cache successful GET responses in-memory to avoid repeated external requests
- reuse cached data in version and migration commands
- add test ensuring release queries hit network once

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab20792ac08326a421cb192eb582cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added in-memory caching for HTTP GET requests, reducing redundant network calls and speeding up repeated operations (e.g., version checks and migration lookups).

* Bug Fixes
  * Improved error messages for failed HTTP requests by including status and response details.

* Refactor
  * Simplified network request handling across commands using a common cached retrieval path.

* Tests
  * Added caching behavior tests and ensured test isolation by clearing the HTTP cache between scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->