### PR TITLE
fix: handle ContextKey removal only for fiber configs

### DIFF
--- a/cmd/internal/migrations/v3/common.go
+++ b/cmd/internal/migrations/v3/common.go
@@ -67,18 +67,14 @@ func removeConfigField(src, field string) string {
 		}
 
 		start := loc[0]
-		// include any leading whitespace and comma
+		// include any leading whitespace and comma, but keep the preceding
+		// newline intact so that formatting is preserved for the previous
+		// field when the target field is removed.
 		for start > 0 {
 			switch src[start-1] {
 			case ' ', '\t':
 				start--
 			case ',':
-				start--
-				for start > 0 && (src[start-1] == ' ' || src[start-1] == '\t') {
-					start--
-				}
-				goto leadDone
-			case '\n':
 				start--
 				for start > 0 && (src[start-1] == ' ' || src[start-1] == '\t') {
 					start--

--- a/cmd/internal/migrations/v3/middleware_locals.go
+++ b/cmd/internal/migrations/v3/middleware_locals.go
@@ -34,11 +34,27 @@ func MigrateMiddlewareLocals(cmd *cobra.Command, cwd string, _, _ *semver.Versio
 			{"basicauth", "ContextPassword", "basicauth.PasswordFromContext(%s)"},
 		}
 
-		for _, e := range extractors {
-			re := regexp.MustCompile(e.pkg + `\.Config{[^}]*` + e.field + `:\s*"([^"]+)"`)
-			matches := re.FindAllStringSubmatch(content, -1)
-			for _, m := range matches {
-				ctxMap[m[1]] = e.replFmt
+		reImport := regexp.MustCompile(`(?m)^\s*(?:import\s+)?(?:([\w\.]+)\s+)?"github\.com/gofiber/fiber/(?:v2|v3)/middleware/([\w]+)"`)
+		imports := map[string]string{}
+		for _, m := range reImport.FindAllStringSubmatch(content, -1) {
+			alias := m[1]
+			pkg := m[2]
+			if alias == "" {
+				alias = pkg
+			}
+			imports[alias] = pkg
+		}
+
+		for alias, pkg := range imports {
+			for _, e := range extractors {
+				if e.pkg != pkg {
+					continue
+				}
+				re := regexp.MustCompile(alias + `\.Config{[^}]*` + e.field + `:\s*"([^"]+)"`)
+				matches := re.FindAllStringSubmatch(content, -1)
+				for _, m := range matches {
+					ctxMap[m[1]] = e.replFmt
+				}
 			}
 		}
 
@@ -59,9 +75,15 @@ func MigrateMiddlewareLocals(cmd *cobra.Command, cwd string, _, _ *semver.Versio
 		reComma := regexp.MustCompile(`(\w+)\s*,\s*(\w+)\s*:=\s*([\w\.]+FromContext\([^\)]+\))`)
 		content = reComma.ReplaceAllString(content, "$1, $2 := $3, true")
 
-		content = removeConfigField(content, "ContextKey")
-		content = removeConfigField(content, "ContextUsername")
-		content = removeConfigField(content, "ContextPassword")
+		for alias := range imports {
+			reCfg := regexp.MustCompile(alias + `\.Config{[^}]*}`)
+			content = reCfg.ReplaceAllStringFunc(content, func(cfg string) string {
+				cfg = removeConfigField(cfg, "ContextKey")
+				cfg = removeConfigField(cfg, "ContextUsername")
+				cfg = removeConfigField(cfg, "ContextPassword")
+				return cfg
+			})
+		}
 
 		return content
 	})

--- a/cmd/internal/migrations/v3/middleware_locals_test.go
+++ b/cmd/internal/migrations/v3/middleware_locals_test.go
@@ -126,3 +126,58 @@ func handler(c fiber.Ctx) error {
 	assert.Contains(t, content, `token := csrf.TokenFromContext(c)`)
 	assert.NotContains(t, content, "ContextKey")
 }
+
+func Test_MigrateMiddlewareLocals_ContextKeyFormatting(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mctxfmt")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import ka "github.com/gofiber/fiber/v2/middleware/keyauth"
+func main() {
+    _ = ka.New(ka.Config{
+        Next:        nil,
+        ContextKey:  "token",
+        SuccessHandler: nil,
+    })
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateMiddlewareLocals(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.NotContains(t, content, "ContextKey")
+	assert.Contains(t, content, "Next:           nil,\n\t\tSuccessHandler: nil")
+}
+
+func Test_MigrateMiddlewareLocals_NonFiberConfig(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mnonfiber")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2"
+
+var ConfigDefault = Config{
+    Next:           nil,
+    SuccessHandler: nil,
+    ErrorHandler:   nil,
+    Validate:       nil,
+    SymmetricKey:   nil,
+    ContextKey:     DefaultContextKey,
+    TokenLookup:    [2]string{LookupHeader, fiber.HeaderAuthorization},
+}
+`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateMiddlewareLocals(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Contains(t, content, "ContextKey:     DefaultContextKey")
+}


### PR DESCRIPTION
## Summary
- preserve struct formatting when removing config fields
- only strip ContextKey from configs belonging to Fiber middlewares
- add regression tests for ContextKey migration
- detect any fiber middleware import for ContextKey removal

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab1fd3a7b8832691094b1dbf50e5e0