### PR TITLE
Persist HTTP cache across CLI runs

### DIFF
--- a/cmd/httpcache.go
+++ b/cmd/httpcache.go
@@ -2,16 +2,66 @@ package cmd
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
+	"time"
 )
 
 var (
 	cacheMu       sync.RWMutex
 	responseCache = make(map[string][]byte)
+
+	cacheDir = filepath.Join(os.TempDir(), "cli-httpcache")
+	cacheTTL = 5 * time.Minute
 )
+
+type cacheEntry struct {
+	Expiry time.Time `json:"expiry"`
+	Body   []byte    `json:"body"`
+}
+
+func cacheFile(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return filepath.Join(cacheDir, hex.EncodeToString(h[:])+".json")
+}
+
+func readFromFile(url string) ([]byte, bool) {
+	b, err := os.ReadFile(cacheFile(url))
+	if err != nil {
+		return nil, false
+	}
+	var e cacheEntry
+	if err := json.Unmarshal(b, &e); err != nil {
+		_ = os.Remove(cacheFile(url)) //nolint:errcheck // best effort cleanup
+		return nil, false
+	}
+	if time.Now().After(e.Expiry) {
+		_ = os.Remove(cacheFile(url)) //nolint:errcheck // remove expired cache
+		return nil, false
+	}
+	return e.Body, true
+}
+
+func writeToFile(url string, body []byte) {
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		return
+	}
+	e := cacheEntry{Expiry: time.Now().Add(cacheTTL), Body: body}
+	b, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(cacheFile(url), b, 0o600); err != nil {
+		return
+	}
+}
 
 // cachedGET performs an HTTP GET request and caches successful responses.
 // Headers may be nil. Only responses with status 200 are cached.
@@ -22,6 +72,13 @@ func cachedGET(ctx context.Context, url string, headers map[string]string) (body
 		return b, http.StatusOK, nil
 	}
 	cacheMu.RUnlock()
+
+	if b, ok := readFromFile(url); ok {
+		cacheMu.Lock()
+		responseCache[url] = b
+		cacheMu.Unlock()
+		return b, http.StatusOK, nil
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -51,6 +108,7 @@ func cachedGET(ctx context.Context, url string, headers map[string]string) (body
 		cacheMu.Lock()
 		responseCache[url] = body
 		cacheMu.Unlock()
+		writeToFile(url, body)
 	}
 
 	return body, res.StatusCode, nil
@@ -61,4 +119,5 @@ func clearHTTPCache() {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 	responseCache = make(map[string][]byte)
+	_ = os.RemoveAll(cacheDir) //nolint:errcheck // best effort cleanup
 }


### PR DESCRIPTION
## Summary
- cache HTTP GET responses in temp files for 5 minutes
- reuse cached responses across CLI invocations

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab2dd208608326ae69893f3424870c