### PR TITLE
Ensure HTTP cache directory exists before locking

### DIFF
--- a/cmd/httpcache.go
+++ b/cmd/httpcache.go
@@ -37,6 +37,11 @@ func cacheFile(url string) string {
 }
 
 func readFromFile(url string) ([]byte, bool) {
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		log.Printf("httpcache: mkdir %s: %v", cacheDir, err)
+		return nil, false
+	}
+
 	lock := flock.New(cacheFile(url) + ".lock")
 	if err := lock.RLock(); err != nil {
 		log.Printf("httpcache: acquire read lock for %s: %v", url, err)
@@ -70,6 +75,11 @@ func readFromFile(url string) ([]byte, bool) {
 }
 
 func writeToFile(url string, body []byte) {
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		log.Printf("httpcache: mkdir %s: %v", cacheDir, err)
+		return
+	}
+
 	lock := flock.New(cacheFile(url) + ".lock")
 	if err := lock.Lock(); err != nil {
 		log.Printf("httpcache: acquire write lock for %s: %v", url, err)
@@ -81,10 +91,6 @@ func writeToFile(url string, body []byte) {
 		}
 	}()
 
-	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
-		log.Printf("httpcache: mkdir %s: %v", cacheDir, err)
-		return
-	}
 	e := cacheEntry{Expiry: time.Now().Add(cacheTTL), Body: body}
 	b, err := json.Marshal(e)
 	if err != nil {

--- a/cmd/httpcache.go
+++ b/cmd/httpcache.go
@@ -26,6 +26,12 @@ var (
 	cacheTTL = 5 * time.Minute
 )
 
+func init() {
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		log.Fatalf("httpcache: mkdir %s: %v", cacheDir, err)
+	}
+}
+
 type cacheEntry struct {
 	Expiry time.Time `json:"expiry"`
 	Body   []byte    `json:"body"`
@@ -37,11 +43,6 @@ func cacheFile(url string) string {
 }
 
 func readFromFile(url string) ([]byte, bool) {
-	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
-		log.Printf("httpcache: mkdir %s: %v", cacheDir, err)
-		return nil, false
-	}
-
 	lock := flock.New(cacheFile(url) + ".lock")
 	if err := lock.RLock(); err != nil {
 		log.Printf("httpcache: acquire read lock for %s: %v", url, err)
@@ -75,11 +76,6 @@ func readFromFile(url string) ([]byte, bool) {
 }
 
 func writeToFile(url string, body []byte) {
-	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
-		log.Printf("httpcache: mkdir %s: %v", cacheDir, err)
-		return
-	}
-
 	lock := flock.New(cacheFile(url) + ".lock")
 	if err := lock.Lock(); err != nil {
 		log.Printf("httpcache: acquire write lock for %s: %v", url, err)
@@ -161,5 +157,6 @@ func clearHTTPCache() {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 	responseCache = make(map[string][]byte)
-	_ = os.RemoveAll(cacheDir) //nolint:errcheck // best effort cleanup
+	_ = os.RemoveAll(cacheDir)       //nolint:errcheck // best effort cleanup
+	_ = os.MkdirAll(cacheDir, 0o750) //nolint:errcheck // recreate cache dir
 }

--- a/cmd/httpcache_test.go
+++ b/cmd/httpcache_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_HTTPCache_ReadWrite(t *testing.T) {
+	clearHTTPCache()
+
+	url := "https://example.com/foo"
+	body := []byte("bar")
+
+	_, ok := readFromFile(url)
+	require.False(t, ok)
+
+	writeToFile(url, body)
+
+	b, ok := readFromFile(url)
+	require.True(t, ok)
+	require.Equal(t, body, b)
+}

--- a/cmd/httpcache_test.go
+++ b/cmd/httpcache_test.go
@@ -8,6 +8,7 @@ import (
 
 func Test_HTTPCache_ReadWrite(t *testing.T) {
 	clearHTTPCache()
+	t.Cleanup(clearHTTPCache)
 
 	url := "https://example.com/foo"
 	body := []byte("bar")


### PR DESCRIPTION
## Summary
- Create the cache directory before acquiring read/write locks to avoid "no such file" errors
- Add a test that exercises reading and writing through the HTTP cache

## Testing
- `GOFLAGS=-mod=mod make lint`
- `GOFLAGS=-mod=mod make test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3541e4a48326bbe8b21059af26ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved HTTP cache reliability by ensuring the cache directory is created before reading and writing.
  - Added clearer logging when cache directory creation fails.

- Tests
  - Added a test covering cache read/write behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->