### PR TITLE
feat: add migration include/exclude filters

### DIFF
--- a/cmd/internal/migrations/filter_test.go
+++ b/cmd/internal/migrations/filter_test.go
@@ -1,0 +1,55 @@
+package migrations_test
+
+import (
+	"bytes"
+	"testing"
+
+	semver "github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gofiber/cli/cmd/internal/migrations"
+)
+
+func fnFoo(cmd *cobra.Command, cwd string, curr, target *semver.Version) error {
+	cmd.Println("foo")
+	return nil
+}
+
+func fnBar(cmd *cobra.Command, cwd string, curr, target *semver.Version) error {
+	cmd.Println("bar")
+	return nil
+}
+
+func Test_DoMigration_IncludeExclude(t *testing.T) {
+	orig := migrations.Migrations
+	migrations.Migrations = []migrations.Migration{
+		{From: ">=0.0.0", To: ">=0.0.0", Functions: []migrations.MigrationFn{fnFoo, fnBar}},
+	}
+	t.Cleanup(func() { migrations.Migrations = orig })
+
+	dir := t.TempDir()
+	curr := semver.MustParse("0.0.0")
+	target := semver.MustParse("1.0.0")
+
+	t.Run("include glob", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, false, []string{"fnF*"}, nil))
+		out := buf.String()
+		assert.Contains(t, out, "foo")
+		assert.NotContains(t, out, "bar")
+	})
+
+	t.Run("exclude regex", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, false, nil, []string{"^fnB.*"}))
+		out := buf.String()
+		assert.Contains(t, out, "foo")
+		assert.NotContains(t, out, "bar")
+	})
+}

--- a/cmd/internal/migrations/lists.go
+++ b/cmd/internal/migrations/lists.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -90,9 +92,37 @@ func migrationName(fn MigrationFn) string {
 	return f
 }
 
+func matchPatternList(name string, patterns []string) bool {
+	for _, p := range patterns {
+		if matchPattern(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchPattern(name, pattern string) bool {
+	if ok, err := filepath.Match(pattern, name); err == nil {
+		if ok {
+			return true
+		}
+		if !isRegexPattern(pattern) {
+			return false
+		}
+	}
+	if re, err := regexp.Compile(pattern); err == nil {
+		return re.MatchString(name)
+	}
+	return name == pattern
+}
+
+func isRegexPattern(p string) bool {
+	return strings.ContainsAny(p, "^$[]()|+?\\")
+}
+
 // DoMigration runs all migrations
 // It will run all migrations that match the current and target version
-func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, skipGoMod, verbose bool) error {
+func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, skipGoMod, verbose bool, include, exclude []string) error {
 	var errs []error
 	var origDeps map[string]map[string]*semver.Version
 	if !skipGoMod {
@@ -114,13 +144,20 @@ func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, s
 
 		if fromC.Check(curr) && toC.Check(target) {
 			for _, fn := range m.Functions {
+				name := migrationName(fn)
+				if len(include) > 0 && !matchPatternList(name, include) {
+					continue
+				}
+				if len(exclude) > 0 && matchPatternList(name, exclude) {
+					continue
+				}
+
 				if verbose {
 					var buf bytes.Buffer
 					origOut := cmd.OutOrStdout()
 					cmd.SetOut(io.MultiWriter(origOut, &buf))
 					err := fn(cmd, cwd, curr, target)
 					cmd.SetOut(origOut)
-					name := migrationName(fn)
 					if buf.Len() == 0 {
 						cmd.Printf("%s: no changes\n", name)
 					} else {
@@ -131,7 +168,7 @@ func DoMigration(cmd *cobra.Command, cwd string, curr, target *semver.Version, s
 					}
 				} else {
 					if err := fn(cmd, cwd, curr, target); err != nil {
-						errs = append(errs, fmt.Errorf("%s: %w", migrationName(fn), err))
+						errs = append(errs, fmt.Errorf("%s: %w", name, err))
 					}
 				}
 			}

--- a/cmd/internal/migrations/lists_test.go
+++ b/cmd/internal/migrations/lists_test.go
@@ -26,7 +26,7 @@ func Test_DoMigration_Verbose(t *testing.T) {
 		var buf bytes.Buffer
 		cmd := &cobra.Command{}
 		cmd.SetOut(&buf)
-		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, false))
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, false, nil, nil))
 		assert.Equal(t, "", buf.String())
 	})
 
@@ -36,7 +36,7 @@ func Test_DoMigration_Verbose(t *testing.T) {
 		var buf bytes.Buffer
 		cmd := &cobra.Command{}
 		cmd.SetOut(&buf)
-		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true))
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true, nil, nil))
 		out := buf.String()
 		assert.Contains(t, out, "Skipping migration from >=1.0.0-0 to >=0.0.0-0")
 		assert.Contains(t, out, "Skipping migration from >=2.0.0-0 to <4.0.0-0")
@@ -64,7 +64,7 @@ require github.com/valyala/fasthttp v1.0.0`
 		var buf bytes.Buffer
 		cmd := &cobra.Command{}
 		cmd.SetOut(&buf)
-		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true))
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true, nil, nil))
 		out := buf.String()
 		assert.Contains(t, out, "MigrateGoPkgs: no changes")
 		assert.Contains(t, out, "Skipping migration from >=2.0.0-0 to <4.0.0-0")
@@ -88,7 +88,7 @@ require github.com/valyala/fasthttp v1.0.0`
 		var buf bytes.Buffer
 		cmd := &cobra.Command{}
 		cmd.SetOut(&buf)
-		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true))
+		require.NoError(t, migrations.DoMigration(cmd, dir, curr, target, true, true, nil, nil))
 		out := buf.String()
 		assert.Contains(t, out, "Migrating Go packages")
 		assert.Contains(t, out, "MigrateGoPkgs: changed")

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -27,6 +27,8 @@ func newMigrateCmd() *cobra.Command {
 	var skipGoMod bool
 	var verbose bool
 	var thirdParty []string
+	var include []string
+	var exclude []string
 
 	cmd := &cobra.Command{
 		Use:   "migrate",
@@ -39,6 +41,8 @@ func newMigrateCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	cmd.Flags().StringVar(&targetHash, "hash", "", "Commit hash for Fiber version")
 	cmd.Flags().StringSliceVar(&thirdParty, "third-party", nil, "Refresh third-party modules (contrib,storage,template). Use a comma-separated list like --third-party=contrib,storage and append @<commit> to pin a commit")
+	cmd.Flags().StringSliceVar(&include, "include", nil, "Comma-separated list of migrations to include. Supports glob and regex patterns")
+	cmd.Flags().StringSliceVar(&exclude, "exclude", nil, "Comma-separated list of migrations to exclude. Supports glob and regex patterns")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		tps := make([]ThirdPartyParam, 0, len(thirdParty))
@@ -61,6 +65,8 @@ func newMigrateCmd() *cobra.Command {
 			SkipGoMod:          skipGoMod,
 			Verbose:            verbose,
 			ThirdParty:         tps,
+			Include:            include,
+			Exclude:            exclude,
 		})
 	}
 
@@ -74,6 +80,8 @@ type MigrateOptions struct {
 	TargetVersionS     string
 	TargetHash         string
 	ThirdParty         []ThirdPartyParam
+	Include            []string
+	Exclude            []string
 	Force              bool
 	SkipGoMod          bool
 	Verbose            bool
@@ -138,7 +146,7 @@ func migrateRunE(cmd *cobra.Command, opts MigrateOptions) error {
 		migrateFromS = migrateFrom.String()
 	}
 
-	err = migrations.DoMigration(cmd, wd, migrateFrom, targetVersion, opts.SkipGoMod, opts.Verbose)
+	err = migrations.DoMigration(cmd, wd, migrateFrom, targetVersion, opts.SkipGoMod, opts.Verbose, opts.Include, opts.Exclude)
 	if err != nil {
 		return fmt.Errorf("migration failed %w", err)
 	}

--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -23,6 +23,8 @@ fiber migrate --to 3.0.0
 - `-f`, `--force` – Force migration even if already on the target version
 - `-s`, `--skip_go_mod` – Skip running `go mod tidy`, `go mod download`, and `go mod vendor`
 - `-v`, `--verbose` – Enable verbose output during migration
+- `--include` – Comma-separated list of migrations to run. Supports glob and regex patterns
+- `--exclude` – Comma-separated list of migrations to skip. Supports glob and regex patterns
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- allow selecting migrations with `--include` and `--exclude` flags
- support glob or regex patterns when filtering migrations
- document new migrator options

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68add1a30a6c8326b7dd067925768aca