### PR TITLE
Include CLI version output in `fiber version` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ fiber upgrade [flags]
 
 ### Synopsis
 
-Print the local and released version number of fiber
+Print the local and released version number of Fiber and the CLI
 
 ```bash
 fiber version [flags]

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,6 +24,8 @@ func versionRun(cmd *cobra.Command, _ []string) {
 	var (
 		cur, latest string
 		err         error
+		cliLatest   string
+		cliErr      error
 		w           = cmd.OutOrStdout()
 	)
 
@@ -37,6 +39,12 @@ func versionRun(cmd *cobra.Command, _ []string) {
 	}
 
 	_, _ = fmt.Fprintf(w, "fiber version: %s (latest %s)\n", cur, latest)
+	if cliLatest, cliErr = LatestCliVersion(); cliErr != nil {
+		_, _ = fmt.Fprintf(w, "fiber cli version: %s (latest check failed: %v)\n", getVersion(), cliErr)
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "fiber cli version: %s (latest %s)\n", getVersion(), cliLatest)
 }
 
 var (

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -19,10 +19,13 @@ func Test_Version_Printer(t *testing.T) {
 		clearHTTPCache()
 
 		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, fakeVersionResponse))
+		httpmock.RegisterResponder(http.MethodGet, latestCliVersionURL, httpmock.NewBytesResponder(200, fakeCliVersionResponse("1.2.3")))
 
 		out, err := runCobraCmd(versionCmd)
 		require.NoError(t, err)
 		at.Contains(out, "2.0.6")
+		at.Contains(out, "fiber cli version:")
+		at.Contains(out, "latest 1.2.3")
 	})
 
 	t.Run("latest err", func(t *testing.T) {
@@ -35,6 +38,20 @@ func Test_Version_Printer(t *testing.T) {
 		out, err := runCobraCmd(versionCmd)
 		require.NoError(t, err)
 		at.Contains(out, "no version")
+	})
+
+	t.Run("cli latest err", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		clearHTTPCache()
+
+		httpmock.RegisterResponder(http.MethodGet, latestVersionURL, httpmock.NewBytesResponder(200, fakeVersionResponse))
+		httpmock.RegisterResponder(http.MethodGet, latestCliVersionURL, httpmock.NewErrorResponder(errors.New("cli network error")))
+
+		out, err := runCobraCmd(versionCmd)
+		require.NoError(t, err)
+		at.Contains(out, "latest check failed")
+		at.Contains(out, "cli network error")
 	})
 }
 


### PR DESCRIPTION
## Summary
- include the current CLI version and its latest release when running `fiber version`
- handle CLI release lookup failures gracefully and cover the new behavior with tests
- document that the command now reports both Fiber and CLI versions

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68db9ad644cc83268e88cdc8346ebbaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Version command now shows local and latest versions for both Fiber and the CLI.
  - Improved messaging when the latest CLI version check fails.

- Documentation
  - Updated README to clarify the version command reports versions for both Fiber and the CLI.

- Tests
  - Added tests covering CLI latest version retrieval and related error handling in the version command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->