### PR TITLE
Add regression test for encryptcookie migrator idempotency

### DIFF
--- a/cmd/internal/migrations/v3/encryptcookie_config_test.go
+++ b/cmd/internal/migrations/v3/encryptcookie_config_test.go
@@ -87,3 +87,30 @@ var _ = encryptcookie.New(encryptcookie.Config{
 	second := readFile(t, file)
 	assert.Equal(t, first, second)
 }
+
+func Test_MigrateEncryptcookieConfig_EncryptorDecryptorMigrated(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mencryptcookiealready")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	input := `package main
+import (
+    "github.com/gofiber/fiber/v2/middleware/encryptcookie"
+)
+var _ = encryptcookie.New(encryptcookie.Config{
+    Encryptor: func(_ string, value, key string) (string, error) { return "", nil },
+    Decryptor: func(_ string, value string, key string) (string, error) { return "", nil },
+})`
+
+	file := writeTempFile(t, dir, input)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateEncryptcookieConfig(cmd, dir, nil, nil))
+
+	content := readFile(t, file)
+	assert.Equal(t, input, content)
+	assert.Empty(t, buf.String())
+}


### PR DESCRIPTION
## Summary
- add a unit test ensuring `MigrateEncryptcookieConfig` leaves Encryptor and Decryptor signatures unchanged once migrated
- verify the migrator does not emit console output when no changes are necessary

## Testing
- make lint
- make test


------
https://chatgpt.com/codex/tasks/task_e_68e6026618b48326be12582d30ec1b53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to confirm encrypt-cookie configuration migrations are idempotent: when configs already use the migrated format, running the migration leaves files unchanged and emits no output. This improves confidence in upgrade paths and guards against regressions. Ensures consistent behavior across environments and supports safer, repeatable runs during upgrades and rollbacks. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->