### PR TITLE
Handle go mod commands in workspace mode

### DIFF
--- a/cmd/internal/go_mod.go
+++ b/cmd/internal/go_mod.go
@@ -30,6 +30,7 @@ func RunGoMod(root string) error {
 	for _, dir := range dirs {
 		for _, args := range commands {
 			cmd := ExecCommand(args[0], args[1:]...) // #nosec G204 -- commands are controlled
+			setGoWorkOffEnv(cmd)
 			cmd.Dir = dir
 			if err := runCmd(cmd); err != nil {
 				return fmt.Errorf("in %s: %w", dir, err)
@@ -37,6 +38,21 @@ func RunGoMod(root string) error {
 		}
 	}
 	return nil
+}
+
+func setGoWorkOffEnv(cmd *exec.Cmd) {
+	env := append([]string{}, os.Environ()...)
+	if len(cmd.Env) > 0 {
+		env = append(env, cmd.Env...)
+	}
+	filtered := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, "GOWORK=") {
+			filtered = append(filtered, e)
+		}
+	}
+	filtered = append(filtered, "GOWORK=off")
+	cmd.Env = filtered
 }
 
 // fiberModuleDirs returns directories under root containing a go.mod file that

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -233,6 +233,8 @@ require github.com/gofiber/fiber/v2 v2.0.0`
 	assert.Len(t, cmds, 3)
 	for _, c := range cmds {
 		assert.Equal(t, dir, c.Dir)
+		assert.Contains(t, c.Env, "GO_WANT_HELPER_PROCESS=1")
+		assert.Contains(t, c.Env, "GOWORK=off")
 	}
 
 	cmds = nil


### PR DESCRIPTION
## Summary
- ensure the CLI runs go mod commands with `GOWORK=off` so vendoring succeeds in workspaces
- extend the RunGoMod test to assert the helper environment is preserved and includes the workspace override

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68e90b317d748326af2bd2b97cc829d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized environment handling for module operations to ensure consistent behavior when running external go mod commands.

* **Tests**
  * Added assertions to validate required environment variables for executed commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->