### PR TITLE
Handle redirect status codes in migration

### DIFF
--- a/cmd/internal/migrations/v3/redirect_methods.go
+++ b/cmd/internal/migrations/v3/redirect_methods.go
@@ -75,34 +75,12 @@ func MigrateRedirectMethods(cmd *cobra.Command, cwd string, _, _ *semver.Version
 				}
 				modified = true
 			case "RedirectBack":
-				redirectCall := &ast.CallExpr{Fun: &ast.SelectorExpr{X: sel.X, Sel: ast.NewIdent("Redirect")}}
-				args := call.Args
-
-				if len(call.Args) > 1 && isStatusArg(call.Args[len(call.Args)-1]) {
-					statusArg := call.Args[len(call.Args)-1]
-					args = call.Args[:len(call.Args)-1]
-					*call = wrapWithRedirectStatus(sel.X, args[0], statusArg, "Back")
-				} else {
-					*call = ast.CallExpr{
-						Fun:  &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent("Back")},
-						Args: args,
-					}
-				}
+				transformRedirectCall(call, sel.X, "Back", func(ctx ast.Expr, args []ast.Expr, status ast.Expr) ast.CallExpr {
+					return wrapWithRedirectStatus(ctx, args[0], status, "Back")
+				})
 				modified = true
 			case "RedirectToRoute":
-				redirectCall := &ast.CallExpr{Fun: &ast.SelectorExpr{X: sel.X, Sel: ast.NewIdent("Redirect")}}
-				args := call.Args
-
-				if len(call.Args) > 1 && isStatusArg(call.Args[len(call.Args)-1]) {
-					statusArg := call.Args[len(call.Args)-1]
-					args = call.Args[:len(call.Args)-1]
-					*call = wrapRouteWithStatus(sel.X, args, statusArg)
-				} else {
-					*call = ast.CallExpr{
-						Fun:  &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent("Route")},
-						Args: args,
-					}
-				}
+				transformRedirectCall(call, sel.X, "Route", wrapRouteWithStatus)
 				modified = true
 			default:
 				return true
@@ -131,6 +109,23 @@ func MigrateRedirectMethods(cmd *cobra.Command, cwd string, _, _ *semver.Version
 
 	cmd.Println("Migrating redirect methods")
 	return nil
+}
+
+func transformRedirectCall(call *ast.CallExpr, ctx ast.Expr, method string, statusWrapper func(ast.Expr, []ast.Expr, ast.Expr) ast.CallExpr) {
+	redirectCall := &ast.CallExpr{Fun: &ast.SelectorExpr{X: ctx, Sel: ast.NewIdent("Redirect")}}
+	args := call.Args
+
+	if len(call.Args) > 1 && isStatusArg(call.Args[len(call.Args)-1]) {
+		statusArg := call.Args[len(call.Args)-1]
+		args = call.Args[:len(call.Args)-1]
+		*call = statusWrapper(ctx, args, statusArg)
+		return
+	}
+
+	*call = ast.CallExpr{
+		Fun:  &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent(method)},
+		Args: args,
+	}
 }
 
 func wrapWithRedirectStatus(ctx, target, status ast.Expr, method string) ast.CallExpr {
@@ -203,7 +198,7 @@ func isStatusArg(expr ast.Expr) bool {
 		return (v.Op == token.ADD || v.Op == token.SUB) && isStatusArg(v.X)
 	case *ast.SelectorExpr:
 		if ident, ok := v.X.(*ast.Ident); ok {
-			return (ident.Name == "fiber" || strings.HasPrefix(ident.Name, "http")) && strings.HasPrefix(v.Sel.Name, "Status")
+			return (ident.Name == "fiber" || ident.Name == "http") && strings.HasPrefix(v.Sel.Name, "Status")
 		}
 	}
 

--- a/cmd/internal/migrations/v3/redirect_methods_test.go
+++ b/cmd/internal/migrations/v3/redirect_methods_test.go
@@ -51,6 +51,8 @@ func handler(c fiber.Ctx) error {
 	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).Route(__fiberRedirectRouteArg0)")
 	assert.Contains(t, content, "__fiberRedirectRouteArg1 := fiber.Map{}")
 	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).Route(__fiberRedirectRouteArg0, __fiberRedirectRouteArg1)")
+	assert.Contains(t, content, "__fiberRedirectRouteArg0 := \"dashboard\"")
+	assert.Contains(t, content, "__fiberRedirectStatus := 308")
 	assert.Contains(t, buf.String(), "Migrating redirect methods")
 }
 


### PR DESCRIPTION
## Summary
- update the redirect migration to move optional status codes into the new Redirect().Status chain before invoking To, Back, or Route
- retain string-based fallback replacement logic for unparsable files while preferring AST rewrites
- expand redirect migration tests to cover status arguments and idempotent transformations

## Testing
- make lint
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b186a6ccc83268627e1f15f4839a2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Migrate redirect transformations to a robust AST-based approach for more accurate, reliable rewrites while preserving arguments and explicit status handling.
  * Better fallback behavior when parsing fails and unchanged files are left intact.
  * Ensures formatted output after transformation.

* **Tests**
  * Expanded tests to cover various redirect patterns, explicit status codes, and repeated migrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->