### PR TITLE
Add migration for cache middleware CacheControl rename

### DIFF
--- a/cmd/internal/migrations/v3/cache_config.go
+++ b/cmd/internal/migrations/v3/cache_config.go
@@ -35,8 +35,37 @@ func MigrateCacheConfig(cmd *cobra.Command, cwd string, _, _ *semver.Version) er
 			s = strings.ReplaceAll(s, "Store:", "Storage:")
 			s = strings.ReplaceAll(s, "Key:", "KeyGenerator:")
 			s = reCacheControl.ReplaceAllStringFunc(s, func(match string) string {
-				value := strings.TrimSpace(strings.TrimPrefix(match, "CacheControl:"))
-				return "DisableCacheControl: " + invertBoolExpr(value)
+				value := strings.TrimPrefix(match, "CacheControl:")
+				value = strings.TrimSpace(value)
+
+				comment := ""
+				if idx := strings.Index(value, "//"); idx != -1 {
+					comment = strings.TrimSpace(value[idx:])
+					value = value[:idx]
+				} else if idx := strings.Index(value, "/*"); idx != -1 {
+					comment = strings.TrimSpace(value[idx:])
+					value = value[:idx]
+				}
+
+				hasComma := strings.HasSuffix(strings.TrimRight(value, " \t"), ",")
+				if hasComma {
+					value = strings.TrimSuffix(strings.TrimRight(value, " \t"), ",")
+				} else if comment != "" && strings.HasSuffix(comment, ",") {
+					hasComma = true
+					comment = strings.TrimSuffix(comment, ",")
+					comment = strings.TrimRight(comment, " \t")
+				}
+
+				value = strings.TrimSpace(value)
+				migrated := "DisableCacheControl: " + invertBoolExpr(value)
+				if hasComma {
+					migrated += ","
+				}
+				if comment != "" {
+					migrated += " " + comment
+				}
+
+				return migrated
 			})
 			return s
 		})

--- a/cmd/internal/migrations/v3/cache_config_test.go
+++ b/cmd/internal/migrations/v3/cache_config_test.go
@@ -42,6 +42,16 @@ var _ = cache.New(cache.Config{
 
 var _ = cache.New(cache.Config{
     CacheControl: !cfg.DisableCacheHeaders,
+})
+
+var _ = cache.New(cache.Config{
+    CacheControl: true, // with comment
+})
+
+var _ = cache.New(cache.Config{ CacheControl: !cfg.DisableCacheHeaders }) // no comma
+
+var _ = cache.New(cache.Config{
+    CacheControl: cfg.EnableCache /* block comment */,
 })`)
 
 	var buf bytes.Buffer
@@ -49,10 +59,13 @@ var _ = cache.New(cache.Config{
 	require.NoError(t, v3.MigrateCacheConfig(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.Contains(t, content, "DisableCacheControl: false")
-	assert.Contains(t, content, "DisableCacheControl: true")
-	assert.Contains(t, content, "DisableCacheControl: !(cfg.EnableCache)")
-	assert.Contains(t, content, "DisableCacheControl: cfg.DisableCacheHeaders")
+	assert.Contains(t, content, "DisableCacheControl: false,")
+	assert.Contains(t, content, "DisableCacheControl: true,")
+	assert.Contains(t, content, "DisableCacheControl: !(cfg.EnableCache),")
+	assert.Contains(t, content, "DisableCacheControl: cfg.DisableCacheHeaders,")
+	assert.Contains(t, content, "DisableCacheControl: false, // with comment")
+	assert.Contains(t, content, "DisableCacheControl: cfg.DisableCacheHeaders}) // no comma")
+	assert.Contains(t, content, "DisableCacheControl: !(cfg.EnableCache), /* block comment */")
 	assert.Contains(t, buf.String(), "Migrating cache middleware configs")
 }
 


### PR DESCRIPTION
## Summary
- update the cache middleware migration to convert CacheControl to DisableCacheControl with inverted semantics and avoid remigrating updated configs
- add migration tests covering CacheControl literal and expression cases plus idempotency

## Testing
- make lint
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b1cae0aa48326a367c05ed50df812)