### PR TITLE
Migrate filesystem middleware to static middleware

### DIFF
--- a/cmd/internal/migrations/v3/filesystem_middleware.go
+++ b/cmd/internal/migrations/v3/filesystem_middleware.go
@@ -11,6 +11,14 @@ import (
 	"github.com/gofiber/cli/cmd/internal"
 )
 
+var (
+	reFilesystemNew          = regexp.MustCompile(`filesystem\.New\s*\(`)
+	reFilesystemRootHTTP     = regexp.MustCompile(`Root:\s*http.Dir\(([^)]+)\)`)
+	reFilesystemRoot         = regexp.MustCompile(`Root:\s*([^,\n]+)`)
+	reFilesystemIndex        = regexp.MustCompile(`Index:\s*([^,\n]+)`)
+	reFilesystemNotFoundFile = regexp.MustCompile(`(?m)^(\s*)(NotFoundFile:\s*[^,\n]+)(,?)`)
+)
+
 func MigrateFilesystemMiddleware(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
 		content = strings.ReplaceAll(content,
@@ -20,25 +28,20 @@ func MigrateFilesystemMiddleware(cmd *cobra.Command, cwd string, _, _ *semver.Ve
 			"github.com/gofiber/fiber/v3/middleware/filesystem",
 			"github.com/gofiber/fiber/v3/middleware/static")
 
-		reNew := regexp.MustCompile(`filesystem\.New\s*\(`)
-		content = reNew.ReplaceAllString(content, `static.New("", `)
+		content = reFilesystemNew.ReplaceAllString(content, `static.New("", `)
 
 		content = strings.ReplaceAll(content, "filesystem.Config{", "static.Config{")
 
-		reRootHTTP := regexp.MustCompile(`Root:\s*http.Dir\(([^)]+)\)`)
-		content = reRootHTTP.ReplaceAllString(content, `FS: os.DirFS($1)`)
+		content = reFilesystemRootHTTP.ReplaceAllString(content, `FS: os.DirFS($1)`)
 
-		reRoot := regexp.MustCompile(`Root:\s*([^,\n]+)`)
-		content = reRoot.ReplaceAllString(content, `FS: os.DirFS($1)`)
+		content = reFilesystemRoot.ReplaceAllString(content, `FS: os.DirFS($1)`)
 
-		reIndex := regexp.MustCompile(`Index:\s*([^,\n]+)`)
-		content = reIndex.ReplaceAllString(content, `IndexNames: []string{$1}`)
+		content = reFilesystemIndex.ReplaceAllString(content, `IndexNames: []string{$1}`)
 
 		// Handle NotFoundFile migration - comment it out and add TODO for NotFoundHandler
 		// Only migrate if not already migrated (check for TODO comment)
 		if !strings.Contains(content, "TODO: Migrate to NotFoundHandler") {
-			reNotFoundFile := regexp.MustCompile(`(?m)^(\s*)(NotFoundFile:\s*[^,\n]+)(,?)`)
-			content = reNotFoundFile.ReplaceAllString(content,
+			content = reFilesystemNotFoundFile.ReplaceAllString(content,
 				`$1// TODO: Migrate to NotFoundHandler (fiber.Handler) - NotFoundFile is deprecated
 $1// $2$3`)
 		}

--- a/cmd/internal/migrations/v3/filesystem_middleware_test.go
+++ b/cmd/internal/migrations/v3/filesystem_middleware_test.go
@@ -3,6 +3,7 @@ package v3_test
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,18 +113,7 @@ func main() {
 	assert.Equal(t, firstContent, secondContent, "Migration should be idempotent")
 
 	// Verify the TODO comment is only present once
-	assert.Equal(t, 1, countOccurrences(secondContent, "TODO: Migrate to NotFoundHandler"))
+	assert.Equal(t, 1, strings.Count(secondContent, "TODO: Migrate to NotFoundHandler"))
 	// Verify the NotFoundFile comment is only present once
-	assert.Equal(t, 1, countOccurrences(secondContent, "// NotFoundFile:"))
-}
-
-// Helper function to count occurrences of a substring
-func countOccurrences(str, substr string) int {
-	count := 0
-	for i := 0; i <= len(str)-len(substr); i++ {
-		if str[i:i+len(substr)] == substr {
-			count++
-		}
-	}
-	return count
+	assert.Equal(t, 1, strings.Count(secondContent, "// NotFoundFile:"))
 }


### PR DESCRIPTION
Extend the filesystem middleware migration to handle NotFoundFile:
- Comment out NotFoundFile configuration (deprecated)
- Add TODO comment referencing NotFoundHandler (fiber.Handler)
- Ensure idempotent migration (no duplicate comments on re-run)

Changes:
- Add regex pattern to detect and comment NotFoundFile
- Only apply migration if TODO comment not already present
- Add test for NotFoundFile migration
- Add test for idempotency to prevent duplicate migrations

Migration transforms:
  NotFoundFile: "index.html", To:
  // TODO: Migrate to NotFoundHandler (fiber.Handler) - NotFoundFile is deprecated // NotFoundFile: "index.html",



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added migration that deprecates NotFoundFile by commenting it out and inserting a TODO guiding transition to NotFoundHandler, avoiding duplicate markers.
* **Tests**
  * Added tests verifying migration behavior and idempotency so repeated runs do not duplicate migration notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->