### PR TITLE
Update contrib migration to fetch v3 module versions

### DIFF
--- a/cmd/internal/migrations/v3/contrib_packages.go
+++ b/cmd/internal/migrations/v3/contrib_packages.go
@@ -74,7 +74,6 @@ func MigrateContribPackages(cmd *cobra.Command, cwd string, _, _ *semver.Version
 		}
 
 		updated := content
-		versions := make(map[string]string)
 
 		for _, match := range matches {
 			rest := strings.TrimPrefix(match, contribPrefix)
@@ -82,13 +81,9 @@ func MigrateContribPackages(cmd *cobra.Command, cwd string, _, _ *semver.Version
 				continue
 			}
 
-			version, ok := versions[rest]
-			if !ok {
-				version, err = contribV3Version(rest)
-				if err != nil {
-					return fmt.Errorf("fetch contrib %s version: %w", rest, err)
-				}
-				versions[rest] = version
+			version, err := contribV3Version(rest)
+			if err != nil {
+				return fmt.Errorf("fetch contrib %s version: %w", rest, err)
 			}
 
 			updated = updateGoModModule(updated, match, contribV3Prefix+rest, version)

--- a/cmd/internal/migrations/v3/contrib_packages_test.go
+++ b/cmd/internal/migrations/v3/contrib_packages_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func Test_MigrateContribPackages(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 
 	restore := v3.SetContribV3VersionFetcher(func(module string) (string, error) {
@@ -61,8 +59,6 @@ require (
 }
 
 func Test_MigrateContribPackages_Replace(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 
 	restore := v3.SetContribV3VersionFetcher(func(module string) (string, error) {
@@ -104,8 +100,6 @@ replace github.com/gofiber/contrib/websocket => ../local`
 }
 
 func Test_MigrateContribPackages_Idempotent(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 
 	restore := v3.SetContribV3VersionFetcher(func(module string) (string, error) {


### PR DESCRIPTION
## Summary
- update contrib package migration to fetch the latest v3 module versions when rewriting go.mod entries
- ensure contrib migration tests stub contrib version fetcher and assert migrated versions are updated

## Testing
- make lint
- make test *(fails due to vendor directory inconsistency between go.mod and vendor/modules.txt)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c71d4d000832687fdc5fedc3a9d87)