### PR TITLE
Simplify redirect migrator output

### DIFF
--- a/cmd/internal/migrations/v3/redirect_methods.go
+++ b/cmd/internal/migrations/v3/redirect_methods.go
@@ -116,62 +116,22 @@ func transformRedirectCall(call *ast.CallExpr, ctx ast.Expr, method string, stat
 func wrapWithRedirectStatus(ctx, target, status ast.Expr, method string) ast.CallExpr {
 	redirectCall := &ast.CallExpr{Fun: &ast.SelectorExpr{X: ctx, Sel: ast.NewIdent("Redirect")}}
 
-	targetIdent := ast.NewIdent("__fiberRedirectTarget")
-	statusIdent := ast.NewIdent("__fiberRedirectStatus")
-
-	redirectStatus := &ast.CallExpr{
-		Fun:  &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent("Status")},
-		Args: []ast.Expr{statusIdent},
-	}
-
-	redirectWithTarget := &ast.CallExpr{
-		Fun:  &ast.SelectorExpr{X: redirectStatus, Sel: ast.NewIdent(method)},
-		Args: []ast.Expr{targetIdent},
-	}
+	redirectStatus := &ast.CallExpr{Fun: &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent("Status")}, Args: []ast.Expr{status}}
 
 	return ast.CallExpr{
-		Fun: &ast.FuncLit{
-			Type: &ast.FuncType{Params: &ast.FieldList{}},
-			Body: &ast.BlockStmt{List: []ast.Stmt{
-				&ast.AssignStmt{Lhs: []ast.Expr{targetIdent}, Tok: token.DEFINE, Rhs: []ast.Expr{target}},
-				&ast.AssignStmt{Lhs: []ast.Expr{statusIdent}, Tok: token.DEFINE, Rhs: []ast.Expr{status}},
-				&ast.ReturnStmt{Results: []ast.Expr{redirectWithTarget}},
-			}},
-		},
+		Fun:  &ast.SelectorExpr{X: redirectStatus, Sel: ast.NewIdent(method)},
+		Args: []ast.Expr{target},
 	}
 }
 
 func wrapRouteWithStatus(ctx ast.Expr, args []ast.Expr, status ast.Expr) ast.CallExpr {
 	redirectCall := &ast.CallExpr{Fun: &ast.SelectorExpr{X: ctx, Sel: ast.NewIdent("Redirect")}}
-	statusIdent := ast.NewIdent("__fiberRedirectStatus")
 
-	var routeArgIdents []ast.Expr
-	var stmts []ast.Stmt
-	for i, arg := range args {
-		ident := ast.NewIdent(fmt.Sprintf("__fiberRedirectRouteArg%d", i))
-		routeArgIdents = append(routeArgIdents, ident)
-		stmts = append(stmts, &ast.AssignStmt{Lhs: []ast.Expr{ident}, Tok: token.DEFINE, Rhs: []ast.Expr{arg}})
-	}
-
-	stmts = append(stmts, &ast.AssignStmt{Lhs: []ast.Expr{statusIdent}, Tok: token.DEFINE, Rhs: []ast.Expr{status}})
-
-	redirectStatus := &ast.CallExpr{
-		Fun:  &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent("Status")},
-		Args: []ast.Expr{statusIdent},
-	}
-
-	redirectRoute := &ast.CallExpr{
-		Fun:  &ast.SelectorExpr{X: redirectStatus, Sel: ast.NewIdent("Route")},
-		Args: routeArgIdents,
-	}
-
-	stmts = append(stmts, &ast.ReturnStmt{Results: []ast.Expr{redirectRoute}})
+	redirectStatus := &ast.CallExpr{Fun: &ast.SelectorExpr{X: redirectCall, Sel: ast.NewIdent("Status")}, Args: []ast.Expr{status}}
 
 	return ast.CallExpr{
-		Fun: &ast.FuncLit{
-			Type: &ast.FuncType{Params: &ast.FieldList{}},
-			Body: &ast.BlockStmt{List: stmts},
-		},
+		Fun:  &ast.SelectorExpr{X: redirectStatus, Sel: ast.NewIdent("Route")},
+		Args: args,
 	}
 }
 

--- a/cmd/internal/migrations/v3/redirect_methods_test.go
+++ b/cmd/internal/migrations/v3/redirect_methods_test.go
@@ -39,20 +39,13 @@ func handler(c fiber.Ctx) error {
 
 	content := readFile(t, file)
 	assert.Contains(t, content, ".Redirect().To(\"/foo\")")
-	assert.Contains(t, content, "__fiberRedirectTarget := \"/bar\"")
-	assert.Contains(t, content, "__fiberRedirectStatus := fiber.StatusPermanentRedirect")
-	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).To(__fiberRedirectTarget)")
+	assert.Contains(t, content, "c.Redirect().Status(fiber.StatusPermanentRedirect).To(\"/bar\")")
 	assert.Contains(t, content, ".Redirect().Back()")
-	assert.Contains(t, content, "__fiberRedirectTarget := \"/fallback\"")
-	assert.Contains(t, content, "__fiberRedirectStatus := 301")
-	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).Back(__fiberRedirectTarget)")
+	assert.Contains(t, content, "c.Redirect().Status(301).Back(\"/fallback\")")
 	assert.Contains(t, content, ".Redirect().Route(\"home\")")
-	assert.Contains(t, content, "__fiberRedirectRouteArg0 := \"home-redirect\"")
-	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).Route(__fiberRedirectRouteArg0)")
-	assert.Contains(t, content, "__fiberRedirectRouteArg1 := fiber.Map{}")
-	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).Route(__fiberRedirectRouteArg0, __fiberRedirectRouteArg1)")
-	assert.Contains(t, content, "__fiberRedirectRouteArg0 := \"dashboard\"")
-	assert.Contains(t, content, "__fiberRedirectStatus := 308")
+	assert.Contains(t, content, "c.Redirect().Status(301).Route(\"home-redirect\")")
+	assert.Contains(t, content, "c.Redirect().Status(fiber.StatusPermanentRedirect).Route(\"dashboard\", fiber.Map{})")
+	assert.Contains(t, content, "c.Redirect().Status(308).Route(\"dashboard\", fiber.Map{})")
 	assert.Contains(t, buf.String(), "Migrating redirect methods")
 }
 
@@ -79,6 +72,5 @@ func handler(c fiber.Ctx) error {
 	require.NoError(t, v3.MigrateRedirectMethods(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.Equal(t, 1, strings.Count(content, "__fiberRedirectStatus := 302"))
-	assert.Contains(t, content, "return c.Redirect().Status(__fiberRedirectStatus).To(__fiberRedirectTarget)")
+	assert.Equal(t, 1, strings.Count(content, "c.Redirect().Status(302).To(\"/foo\")"))
 }


### PR DESCRIPTION
## Summary
- update the redirect migrator to chain Status/To/Back/Route calls without generating temporary variables
- refresh redirect migrator tests to expect chained redirect outputs

## Testing
- make lint
- make test (fails: inconsistent vendoring in go.mod vs vendor/modules.txt)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c84363b088326b2b2c3ea099eb849)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal redirect method generation by streamlining code structure and removing unnecessary intermediate constructs. This reduces complexity in generated redirect calls while maintaining equivalent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->