### PR TITLE
Ensure context migration is idempotent

### DIFF
--- a/cmd/internal/migrations/v3/context_methods.go
+++ b/cmd/internal/migrations/v3/context_methods.go
@@ -19,6 +19,10 @@ import (
 func MigrateContextMethods(cmd *cobra.Command, cwd string, _, _ *semver.Version) error {
 	changed, err := internal.ChangeFileContent(cwd, func(content string) string {
 		orig := content
+		const migrationMarker = "// fiber:context-methods migrated"
+		if strings.Contains(orig, migrationMarker) {
+			return content
+		}
 
 		// old Context() returned fasthttp.RequestCtx
 		if !strings.Contains(orig, ".SetContext(") {
@@ -77,6 +81,14 @@ func MigrateContextMethods(cmd *cobra.Command, cwd string, _, _ *semver.Version)
 			}
 			return match
 		})
+
+		if content != orig && !strings.Contains(content, migrationMarker) {
+			if strings.HasSuffix(content, "\n") {
+				content += migrationMarker + "\n"
+			} else {
+				content += "\n" + migrationMarker + "\n"
+			}
+		}
 
 		return content
 	})

--- a/cmd/internal/migrations/v3/context_methods_test.go
+++ b/cmd/internal/migrations/v3/context_methods_test.go
@@ -131,6 +131,37 @@ func handler(c fiber.Ctx) error {
 	assert.Equal(t, 2, strings.Count(second, "SetContext("))
 }
 
+func Test_MigrateContextMethods_UserContextOnlyMultipleRuns(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mcmtestuserctx")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+import "github.com/gofiber/fiber/v2"
+func handler(c fiber.Ctx) error {
+    ctx := c.UserContext()
+    _ = ctx
+    return nil
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateContextMethods(cmd, dir, nil, nil))
+
+	first := readFile(t, file)
+	require.Contains(t, first, "ctx := c.Context()")
+	require.NotContains(t, first, ".RequestCtx()")
+	require.Contains(t, first, "// fiber:context-methods migrated")
+
+	require.NoError(t, v3.MigrateContextMethods(cmd, dir, nil, nil))
+	second := readFile(t, file)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, strings.Count(second, "ctx := c.Context()"))
+	assert.Equal(t, 0, strings.Count(second, ".RequestCtx()"))
+}
+
 func Test_MigrateContextMethods_SkipNonFiber(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a migration marker so context method rewrites are applied only once per file
- append the marker when UserContext/SetUserContext migrations adjust a file
- add a regression test to ensure rerunning the migration does not convert new Context calls to RequestCtx

## Testing
- make lint
- make test *(fails: vendor directory is out of sync with go.mod; go recommends running `go mod vendor`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8503724483269ec3fa0e81c4eac3)