### PR TITLE
Fix static config migration for Fiber v3

### DIFF
--- a/cmd/internal/migrations/v3/static_routes.go
+++ b/cmd/internal/migrations/v3/static_routes.go
@@ -39,7 +39,8 @@ func MigrateStaticRoutes(cmd *cobra.Command, cwd string, _, _ *semver.Version) e
 
 			if cfg != "" {
 				cfg = strings.TrimSpace(cfg)
-				cfg = strings.Replace(cfg, "Static{", "static.Config{", 1)
+				reCfg := regexp.MustCompile(`\b(?:[a-zA-Z_]\w*\.)?Static{`)
+				cfg = reCfg.ReplaceAllString(cfg, "static.Config{")
 				reIndex := regexp.MustCompile(`Index:\s*([^,}\n]+)`)
 				cfg = reIndex.ReplaceAllString(cfg, "IndexNames: []string{$1}")
 				return fmt.Sprintf(".Get(%s, static.New(%s, %s))", quoted, root, cfg)

--- a/cmd/internal/migrations/v3/static_routes_test.go
+++ b/cmd/internal/migrations/v3/static_routes_test.go
@@ -24,6 +24,7 @@ func main() {
     app := fiber.New()
     app.Static("/", "./public")
     app.Static("/prefix", "./public", Static{Index: "index.htm"})
+    app.Static("/fiber", "./public", fiber.Static{Compress: true})
 }`)
 
 	var buf bytes.Buffer
@@ -34,5 +35,7 @@ func main() {
 	assert.Contains(t, content, "\"github.com/gofiber/fiber/v3/middleware/static\"")
 	assert.Contains(t, content, `.Get("/*", static.New("./public"))`)
 	assert.Contains(t, content, `static.New("./public", static.Config{IndexNames: []string{"index.htm"}})`)
+	assert.Contains(t, content, `static.New("./public", static.Config{Compress: true})`)
+	assert.NotContains(t, content, "fiber.static.Config")
 	assert.Contains(t, buf.String(), "Migrating app.Static usage")
 }


### PR DESCRIPTION
## Summary
- ensure static route migration rewrites fiber static configs to the v3 static.Config type
- expand the static route migration test to cover fiber.Static configurations

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c859242048326a3b5bf478b7c219e)