### PR TITLE
Fix swagger package migration targets

### DIFF
--- a/cmd/internal/migrations/v3/swagger_packages.go
+++ b/cmd/internal/migrations/v3/swagger_packages.go
@@ -21,9 +21,9 @@ import (
 
 const (
 	contribSwaggerOld   = "github.com/gofiber/contrib/swagger"
-	contribSwaggerNew   = "github.com/gofiber/contrib/v3/swaggo"
+	contribSwaggerNew   = "github.com/gofiber/contrib/v3/swaggerui"
 	fiberSwaggerOld     = "github.com/gofiber/swagger"
-	fiberSwaggerNew     = "github.com/gofiber/contrib/v3/swaggerui"
+	fiberSwaggerNew     = "github.com/gofiber/contrib/v3/swaggo"
 	goModVersionPattern = `v[a-zA-Z0-9.+-]+`
 )
 
@@ -81,31 +81,31 @@ func migrateSwaggerModules(cwd string) (bool, error) {
 		}
 		content := string(b)
 
-		needsSwaggo := strings.Contains(content, contribSwaggerOld) || strings.Contains(content, contribSwaggerNew)
-		needsSwaggerUI := strings.Contains(content, fiberSwaggerOld) || strings.Contains(content, fiberSwaggerNew)
+		needsSwaggerUI := strings.Contains(content, contribSwaggerOld) || strings.Contains(content, contribSwaggerNew)
+		needsSwaggo := strings.Contains(content, fiberSwaggerOld) || strings.Contains(content, fiberSwaggerNew)
 		if !needsSwaggo && !needsSwaggerUI {
 			return nil
 		}
 
-		if needsSwaggo && swaggoVersion == "" {
-			swaggoVersion, err = contribV3Version("swaggo")
-			if err != nil {
-				return fmt.Errorf("fetch swaggo version: %w", err)
-			}
-		}
 		if needsSwaggerUI && swaggerUIVersion == "" {
 			swaggerUIVersion, err = contribV3Version("swaggerui")
 			if err != nil {
 				return fmt.Errorf("fetch swaggerui version: %w", err)
 			}
 		}
+		if needsSwaggo && swaggoVersion == "" {
+			swaggoVersion, err = contribV3Version("swaggo")
+			if err != nil {
+				return fmt.Errorf("fetch swaggo version: %w", err)
+			}
+		}
 
 		updated := content
-		if needsSwaggo {
-			updated = updateGoModModule(updated, contribSwaggerOld, contribSwaggerNew, swaggoVersion)
-		}
 		if needsSwaggerUI {
-			updated = updateGoModModule(updated, fiberSwaggerOld, fiberSwaggerNew, swaggerUIVersion)
+			updated = updateGoModModule(updated, contribSwaggerOld, contribSwaggerNew, swaggerUIVersion)
+		}
+		if needsSwaggo {
+			updated = updateGoModModule(updated, fiberSwaggerOld, fiberSwaggerNew, swaggoVersion)
 		}
 
 		if updated == content {

--- a/cmd/internal/migrations/v3/swagger_packages_test.go
+++ b/cmd/internal/migrations/v3/swagger_packages_test.go
@@ -22,9 +22,9 @@ func Test_MigrateSwaggerPackages(t *testing.T) {
 	restore := v3.SetContribV3VersionFetcher(func(module string) (string, error) {
 		switch module {
 		case swaggoModule:
-			return "v3.0.1", nil
-		case swaggerUIModule:
 			return "v3.1.0", nil
+		case swaggerUIModule:
+			return "v3.0.1", nil
 		default:
 			return "", fmt.Errorf("unexpected module %s", module)
 		}
@@ -54,11 +54,11 @@ replace github.com/gofiber/contrib/swagger => ../local`
 	require.NoError(t, v3.MigrateSwaggerPackages(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.Contains(t, content, `swagger "github.com/gofiber/contrib/v3/swaggo"`)
+	assert.Contains(t, content, `swagger "github.com/gofiber/contrib/v3/swaggerui"`)
 
 	mod := readFile(t, filepath.Join(dir, "go.mod"))
-	assert.Contains(t, mod, "github.com/gofiber/contrib/v3/swaggo v3.0.1")
-	assert.Contains(t, mod, "replace github.com/gofiber/contrib/v3/swaggo => ../local")
+	assert.Contains(t, mod, "github.com/gofiber/contrib/v3/swaggerui v3.0.1")
+	assert.Contains(t, mod, "replace github.com/gofiber/contrib/v3/swaggerui => ../local")
 
 	assert.Contains(t, buf.String(), "Migrating swagger packages")
 }
@@ -67,9 +67,9 @@ func Test_MigrateSwaggerPackages_FiberSwagger(t *testing.T) {
 	restore := v3.SetContribV3VersionFetcher(func(module string) (string, error) {
 		switch module {
 		case swaggoModule:
-			return "v3.0.0", nil
-		case swaggerUIModule:
 			return "v3.2.0", nil
+		case swaggerUIModule:
+			return "v3.0.0", nil
 		default:
 			return "", fmt.Errorf("unexpected module %s", module)
 		}
@@ -101,10 +101,10 @@ require github.com/gofiber/swagger v1.1.0
 	require.NoError(t, v3.MigrateSwaggerPackages(cmd, dir, nil, nil))
 
 	content := readFile(t, file)
-	assert.Contains(t, content, `swagger "github.com/gofiber/contrib/v3/swaggerui"`)
+	assert.Contains(t, content, `swagger "github.com/gofiber/contrib/v3/swaggo"`)
 
 	mod := readFile(t, filepath.Join(dir, "go.mod"))
-	assert.Contains(t, mod, "github.com/gofiber/contrib/v3/swaggerui v3.2.0")
+	assert.Contains(t, mod, "github.com/gofiber/contrib/v3/swaggo v3.2.0")
 
 	assert.Contains(t, buf.String(), "Migrating swagger packages")
 }


### PR DESCRIPTION
## Summary
- update swagger migration to map contrib/swagger to contrib/v3/swaggerui and github.com/gofiber/swagger to contrib/v3/swaggo
- ensure go.mod updates fetch the correct contrib module versions
- adjust swagger migration tests to reflect the new import targets

## Testing
- make lint
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d864495d48326a02a4b0dcecaa476)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Swagger dependency module path mapping during migrations to ensure proper package resolution and import rewriting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->