### PR TITLE
Handle AcquireAgent without response usage

### DIFF
--- a/cmd/internal/migrations/v3/client_usage.go
+++ b/cmd/internal/migrations/v3/client_usage.go
@@ -171,16 +171,34 @@ func rewriteAcquireAgentBlocks(content string) (string, bool) {
 		for structStart < len(lines) && strings.TrimSpace(lines[structStart]) == "" {
 			structStart++
 		}
+		methodName := methodFromExpr(methodExpr)
+		configLine := buildConfig(headers)
 		if structStart >= len(lines) {
-			out = append(out, line)
+			respLine := fmt.Sprintf("%s_, err := client.%s(%s%s)", indent, methodName, uriExpr, configLine)
+			out = append(out, respLine)
+			out = append(out, parseIndent+"if err != nil {")
+			out = append(out, parseBody[:len(parseBody)-1]...)
+			out = append(out, parseIndent+"}")
+
+			i = parseEnd
+			changed = true
 			continue
 		}
 
 		structMatch := structAssignPattern.FindStringSubmatch(lines[structStart])
 		bytesMatch := bytesAssignPattern.FindStringSubmatch(lines[structStart])
 		stringMatch := stringAssignPattern.FindStringSubmatch(lines[structStart])
-		methodName := methodFromExpr(methodExpr)
-		configLine := buildConfig(headers)
+		if len(structMatch) == 0 && len(bytesMatch) == 0 && len(stringMatch) == 0 {
+			respLine := fmt.Sprintf("%s_, err := client.%s(%s%s)", indent, methodName, uriExpr, configLine)
+			out = append(out, respLine)
+			out = append(out, parseIndent+"if err != nil {")
+			out = append(out, parseBody[:len(parseBody)-1]...)
+			out = append(out, parseIndent+"}")
+
+			i = structStart - 1
+			changed = true
+			continue
+		}
 
 		switch {
 		case len(structMatch) > 0 && structMatch[5] == agentVar:

--- a/cmd/internal/migrations/v3/client_usage_internal_test.go
+++ b/cmd/internal/migrations/v3/client_usage_internal_test.go
@@ -88,6 +88,51 @@ func handler(ctx *fiber.Ctx, code string) error {
 	assert.Equal(t, expected, formatted)
 }
 
+func Test_rewriteAcquireAgentBlocks_NoResponseUsage(t *testing.T) {
+	content := `package main
+
+import (
+"fmt"
+
+"github.com/gofiber/fiber/v3"
+)
+
+func handler(ctx *fiber.Ctx, code string) error {
+a := fiber.AcquireAgent()
+req := a.Request()
+req.Header.SetMethod(fiber.MethodPost)
+req.Header.Set("accept", "application/json")
+req.SetRequestURI(fmt.Sprintf("https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s", models.ClientID, models.ClientSecret, code))
+if err := a.Parse(); err != nil {
+models.SYSLOG.Errorf("could not create HTTP request: %v", err)
+}
+
+return nil
+}`
+
+	updated, changed := rewriteAcquireAgentBlocks(content)
+	require.True(t, changed, "expected rewrite")
+	formatted := gofmtSource(t, updated)
+	expected := gofmtSource(t, `package main
+
+import (
+    "fmt"
+
+    "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/client"
+)
+
+func handler(ctx *fiber.Ctx, code string) error {
+    _, err := client.Post(fmt.Sprintf("https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s", models.ClientID, models.ClientSecret, code), client.Config{Header: map[string]string{"accept": "application/json"}})
+    if err != nil {
+        models.SYSLOG.Errorf("could not create HTTP request: %v", err)
+    }
+    return nil
+}`)
+
+	assert.Equal(t, expected, formatted)
+}
+
 func gofmtSource(t *testing.T, src string) string {
 	t.Helper()
 

--- a/cmd/internal/migrations/v3/client_usage_test.go
+++ b/cmd/internal/migrations/v3/client_usage_test.go
@@ -341,6 +341,59 @@ func handler(ctx *fiber.Ctx, code string) error {
 	assert.Equal(t, expected, content)
 }
 
+func Test_MigrateClientUsage_RewritesAcquireAgentWithoutResponse(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "mclientagent")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.RemoveAll(dir)) }()
+
+	file := writeTempFile(t, dir, `package main
+
+import (
+    "fmt"
+
+    "github.com/gofiber/fiber/v3"
+)
+
+func handler(ctx *fiber.Ctx, code string) error {
+    a := fiber.AcquireAgent()
+    req := a.Request()
+    req.Header.SetMethod(fiber.MethodPost)
+    req.Header.Set("accept", "application/json")
+    req.SetRequestURI(fmt.Sprintf("https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s", models.ClientID, models.ClientSecret, code))
+    if err := a.Parse(); err != nil {
+        models.SYSLOG.Errorf("could not create HTTP request: %v", err)
+    }
+
+    return nil
+}`)
+
+	var buf bytes.Buffer
+	cmd := newCmd(&buf)
+	require.NoError(t, v3.MigrateClientUsage(cmd, dir, nil, nil))
+
+	content := gofmtSource(t, readFile(t, file))
+	expected := gofmtSource(t, `package main
+
+import (
+    "fmt"
+
+    "github.com/gofiber/fiber/v3"
+    "github.com/gofiber/fiber/v3/client"
+)
+
+func handler(ctx *fiber.Ctx, code string) error {
+    _, err := client.Post(fmt.Sprintf("https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s", models.ClientID, models.ClientSecret, code), client.Config{Header: map[string]string{"accept": "application/json"}})
+    if err != nil {
+        models.SYSLOG.Errorf("could not create HTTP request: %v", err)
+    }
+    return nil
+}`)
+
+	assert.Equal(t, expected, content)
+}
+
 func Test_MigrateClientUsage_RewritesHeadersQueriesAndTimeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- update the client usage migrator to rewrite AcquireAgent flows that only parse requests without consuming responses
- add unit and integration tests covering the new migration scenario

## Testing
- make lint
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693280efc9f0832690144f5600b32142)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for internal code migration scenarios.

* **Chores**
  * Internal migration improvements with enhanced error handling patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->