### PR TITLE
chore: serve was added twice

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -48,8 +48,6 @@ func init() {
 	serveCmd.Flags().BoolVar(&serveByteRange, "range", false, "enable byte range requests")
 	serveCmd.Flags().BoolVar(&servePrefork, "prefork", false, "enable prefork mode")
 	serveCmd.Flags().BoolVar(&serveQuiet, "quiet", false, "disable startup message")
-
-	rootCmd.AddCommand(serveCmd)
 }
 
 var serveCmd = &cobra.Command{


### PR DESCRIPTION

<img width="758" height="556" alt="image" src="https://github.com/user-attachments/assets/8cc8ffa0-d720-4e12-9efd-f6d687a33275" />

# Pull Request Guide
removed the 2nd one. now the help is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The serve command is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->